### PR TITLE
fix: resolve CI/CD workflow failures

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -138,7 +138,7 @@ jobs:
         uses: trufflesecurity/trufflehog@main
         with:
           path: ./
-          base: main
+          base: ${{ github.event.before }}
           head: HEAD
           extra_args: --debug --only-verified
 
@@ -153,6 +153,7 @@ jobs:
     outputs:
       image-digest: ${{ steps.build.outputs.digest }}
       image-tag: ${{ steps.meta.outputs.tags }}
+      image-primary: ${{ steps.get-primary-tag.outputs.primary-tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -192,6 +193,15 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
           no-cache: ${{ inputs.force_rebuild || false }}
+
+      - name: Get primary tag for security scan
+        id: get-primary-tag
+        run: |
+          # Extract the first tag from the multi-line tags output for security scanning
+          TAGS="${{ steps.meta.outputs.tags }}"
+          PRIMARY_TAG=$(echo "$TAGS" | head -n 1)
+          echo "primary-tag=$PRIMARY_TAG" >> $GITHUB_OUTPUT
+          echo "Primary tag for security scan: $PRIMARY_TAG"
 
   test:
     name: Test Runner Configuration
@@ -302,7 +312,7 @@ jobs:
       - name: Run Trivy vulnerability scanner on container
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: ${{ needs.build.outputs.image-tag }}
+          image-ref: ${{ needs.build.outputs.image-primary }}
           format: "sarif"
           output: "trivy-container-results.sarif"
 


### PR DESCRIPTION
## 🛠️ Fix CI/CD Workflow Issues

This PR resolves the workflow failures identified in run [17472997639](https://github.com/GrammaTonic/github-runner/actions/runs/17472997639):

### Issues Fixed

#### 1. **TruffleHog Secret Scanning** 
- **Problem**: BASE and HEAD commits were the same on direct push to main
- **Solution**: Use `github.event.before` as base commit for proper diff scanning
- **Impact**: Secret scanning will now work correctly for all push events

#### 2. **Container Security Scan (Trivy)**
- **Problem**: Multiple image tags were passed as concatenated string causing parse error
- **Solution**: Extract primary tag from multi-line output for security scanning
- **Impact**: Container vulnerability scanning will now work with single image reference

### Changes Made

- Modified TruffleHog step to use `github.event.before` as base commit
- Added `get-primary-tag` step to extract first tag from build output
- Updated Trivy container scan to use `image-primary` output
- Added proper image reference handling for security scanning

### Testing

- [x] Workflow syntax validation passes
- [x] Changes address root cause of both failures
- [x] No breaking changes to existing functionality

This fix ensures both security scanning tools work correctly while maintaining all existing CI/CD functionality.