### PR TITLE
Fix Docker Context Inconsistency in Security Workflow

### DIFF
--- a/.github/workflows/security-advisories.yml
+++ b/.github/workflows/security-advisories.yml
@@ -87,7 +87,7 @@ jobs:
         if: contains(steps.params.outputs.scan_targets, 'container')
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ./docker
           file: ./docker/Dockerfile
           push: false
           tags: github-runner:scan
@@ -138,7 +138,7 @@ jobs:
         if: contains(steps.params.outputs.scan_targets, 'chrome')
         uses: docker/build-push-action@v5
         with:
-          context: .
+          context: ./docker
           file: ./docker/Dockerfile.chrome
           push: false
           tags: github-runner-chrome:scan


### PR DESCRIPTION
## Problem

The CI/CD pipeline was experiencing recurring failures with Docker builds because of inconsistent build contexts between workflows:
- CI/CD workflow uses `context: ./docker`
- Security workflow was using `context: .`

This caused Docker COPY commands to fail when looking for entrypoint scripts:
- `COPY entrypoint.sh` failed in security workflow builds
- `COPY entrypoint-chrome.sh` failed in Chrome builds

## Solution

Standardized Docker build context across all workflows by changing security workflow from `context: .` to `context: ./docker` to match the CI/CD workflow.

## Changes

- Updated `.github/workflows/security-advisories.yml` to use consistent Docker context
- Changed both runner and chrome-runner build contexts to `./docker`

## Testing

This should resolve the recurring Docker build failures referenced in workflow runs like 17499428637 and 17501927490.

Fixes the issue where "every time you fix [the pipeline] you brake the cicd pipeline"