### PR TITLE
ci: adapt user-deployment job for develop-centric flow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,7 +9,6 @@ This repository is for setting up and managing GitHub Actions self-hosted runner
 ### Branch Protection Status - ENFORCED
 
 - **`main` branch**: PROTECTED with branch protection rules
-- **`develop` branch**: PROTECTED with branch protection rules
 - **Direct pushes BLOCKED**: All changes must go through pull requests
 - **Review required**: 1 approving review required before merge
 - **Status checks required**: CI/CD Pipeline must pass before merge
@@ -18,14 +17,14 @@ This repository is for setting up and managing GitHub Actions self-hosted runner
 
 ### Development Workflow - MANDATORY
 
-1. **Start from develop**: Always create feature branches from `develop` branch
-2. **Feature development**: Work on features/fixes in dedicated feature branches
-3. **Pull Request workflow**: Submit PR from feature branch → `develop`
-4. **Code review & CI**: Get 1+ approval AND CI/CD Pipeline must pass
-5. **Merge to develop**: After approval and green CI, merge to `develop`
-6. **Release process**: Create PR from `develop` → `main` for releases
+1. **Start from develop**: Create feature branches from the integration branch `develop`.
+2. **Feature development**: Work on features/fixes in dedicated feature branches created from `develop`.
+3. **Pull Request workflow**: Submit PR from feature branch → `develop` for integration and review.
+4. **Code review & CI**: Get 1+ approval AND CI/CD Pipeline must pass on the `develop` PR.
+5. **Merge to develop**: After approval and green CI, merge to `develop`.
+6. **Release process**: Maintainers create a PR from `develop` → `main` to promote integration to production.
 
-**CRITICAL**: Direct pushes to `main` and `develop` are now IMPOSSIBLE due to branch protection.
+**CRITICAL**: Direct pushes to `main` are blocked by branch protection; promotions to `main` must be done via PR from `develop`.
 
 ### Branch Protection Management
 
@@ -147,7 +146,7 @@ This repository is for setting up and managing GitHub Actions self-hosted runner
 git clone <repo-url>
 cd github-runner
 
-# Switch to develop branch (primary development branch)
+# Switch to develop branch (integration branch)
 git checkout develop
 git pull origin develop
 
@@ -215,15 +214,15 @@ docker compose -f docker/docker-compose.chrome.yml up -d --scale github-runner-c
 
 ### Development Workflow - UPDATED
 
-1. **Start from develop**: Always create feature branches from protected `develop` branch
+1. **Start from main**: Always create feature branches from protected `main` branch
 2. **Work on features**: Implement features, hotfixes on feature branches
 3. **Test thoroughly**: Ensure changes work and pass all CI/CD tests
-4. **Create PR to develop**: Submit pull request from feature branch → `develop`
+4. **Create PR to main**: Submit pull request from feature branch → `main`
 5. **Code review & CI**: Get 1+ approval AND CI/CD Pipeline must pass (required by branch protection)
-6. **Merge to develop**: After approval and green CI, merge to `develop`
-7. **Release process**: Create PR from `develop` → `main` for releases (triggers User Deployment Experience Tests)
+6. **Merge to main**: After approval and green CI, merge to `main`
+7. **Release process**: Create PR from `main` → `release/*` or tag releases from `main` (triggers User Deployment Experience Tests)
 
-**CRITICAL**: Direct pushes to `main` and `develop` are IMPOSSIBLE due to branch protection rules.
+**CRITICAL**: Direct pushes to `main` are IMPOSSIBLE due to branch protection rules.
 
 ### Common Operations
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -631,7 +631,10 @@ jobs:
     name: User Deployment Experience Tests
     runs-on: ubuntu-latest
     needs: [build, build-chrome]
-    if: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'develop'  }}
+    # Run on either:
+    #  - Feature PRs targeting 'develop' (feature -> develop), so we validate user deployment experience early
+    #  - Promotion PRs from 'develop' into 'main' (develop -> main), so we validate release promotions
+    if: ${{ github.event_name == 'pull_request' && (github.event.pull_request.base.ref == 'develop' || (github.event.pull_request.base.ref == 'main' && github.event.pull_request.head.ref == 'develop')) }}
     permissions:
       contents: read
 

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,5 +1,15 @@
 name: CI/CD Pipeline
 
+# Canonical branch flow for this repository:
+# - Feature work: create feature branches from `develop` and open PRs targeting `develop` (feature -> develop).
+# - Integration: merge feature PRs into `develop` and run integration/user-experience checks on those PRs.
+# - Promotion: create a PR from `develop` -> `main` to promote integrated changes to production; CI also validates promotions.
+#
+# Jobs in this workflow are intentionally conservative:
+# - Many jobs run on both `develop` and `main` pushes to keep staging and deployment paths intact.
+# - Job-level `if:` guards that check `github.event.pull_request.base.ref` are updated to account for feature PRs targeting `develop` as well as promotion PRs from `develop`->`main`.
+# Edit with care: updating triggers or branch checks may affect deployment or baseline seeding behavior.
+
 on:
   push:
     branches: [main, develop]

--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ We welcome contributions! Please see our [Contributing Guide](docs/community/CON
 git clone https://github.com/yourusername/github-runner.git
 cd github-runner
 
-# Switch to develop branch (primary development branch)
+# Switch to develop branch (integration branch)
 git checkout develop
 git pull origin develop
 
@@ -436,7 +436,7 @@ make test
 # Submit pull request to develop branch
 ```
 
-**Important**: All development work should be done on the `develop` branch. Never work directly on `main`.
+**Important**: All regular development work should be done on feature branches created from `develop` and merged into `develop` via pull requests. Never commit directly to `main`. Hotfixes may be created from `main` when necessary and must be merged back into `develop` afterwards.
 
 ## 📄 License
 

--- a/docs/SETUP_SUMMARY.md
+++ b/docs/SETUP_SUMMARY.md
@@ -5,7 +5,7 @@
 ### 1. **Repository Structure**
 
 - **Main Branch**: Production-ready code with maximum protection
-- **Develop Branch**: Integration branch with standard protection
+- **Main Branch**: Integration branch with standard protection
 - **Feature Branches**: Developer-managed branches (no protection)
 - **Hotfix Branches**: Emergency fix branches with bypass capability
 
@@ -37,7 +37,7 @@
   - Conversation resolution: Required
 ```
 
-#### **Develop Branch Protection**
+#### **Main Branch Protection**
 
 ```yaml
 ✅ Required Status Checks:
@@ -86,7 +86,7 @@
 ### 5. **GitHub Environments**
 
 - ✅ **Staging Environment**:
-  - Automatic deployment from develop/main branches
+  - Automatic deployment from main branches
   - No manual approval required
   - Custom branch policies enabled
 - ✅ **Production Environment**:
@@ -109,7 +109,7 @@ All existing workflows are fully integrated:
 #### **Active Protection Rules**
 
 - 🔒 **Main Branch**: Fully protected, PR-only access
-- 🔒 **Develop Branch**: Protected with required reviews
+- 🔒 **Main Branch**: Protected with required reviews
 - 📝 **Pull Request #1**: Created to demonstrate workflow
 - 🚨 **Emergency Tools**: Ready for critical incidents
 

--- a/docs/community/CONTRIBUTING.md
+++ b/docs/community/CONTRIBUTING.md
@@ -9,7 +9,7 @@ Thank you for considering contributing to this project! We welcome contributions
    ```bash
    git clone https://github.com/your-username/github-runner.git
    ```
-3. **Switch to Develop**: Always start from and work on the `develop` branch.
+3. **Start from Develop**: This repository uses an integration branch workflow. Create feature branches from `develop` and open pull requests to `develop`.
    ```bash
    git checkout develop
    git pull origin develop
@@ -17,8 +17,8 @@ Thank you for considering contributing to this project! We welcome contributions
 4. **Create a Branch**: Create a new branch for your changes from `develop`.
    ```bash
    git checkout -b feature/your-feature-name
-   # or for hotfixes:
-   git checkout -b hotfix/your-fix-name
+   # For urgent production hotfixes, branch from main instead:
+   # git checkout -b hotfix/your-fix-name main
    ```
 5. **Make Changes**: Make your changes in the new branch.
 6. **Test Your Changes**: Ensure your changes work as expected and do not break existing functionality.
@@ -30,16 +30,29 @@ Thank you for considering contributing to this project! We welcome contributions
    ```bash
    git push origin feature/your-feature-name
    ```
-9. **Open a Pull Request**: Open a pull request from your branch to the `develop` branch of this repository.
+9. **Open a Pull Request**: Open a pull request from your feature branch to the `develop` branch of this repository.
+
+10. **Release / Promote**: After your change is merged into `develop`, the integration branch is promoted to `main` via a pull request from `develop` → `main`. The release flow is:
+
+- feature/\* → PR → develop
+- develop → PR → main
+
+To create the feature PR:
+
+```bash
+gh pr create --base develop --title "feat: ..." --body "..."
+```
+
+To promote develop to main (maintainers):
+
+```bash
+# After tests and approvals on develop
+gh pr create --base main --head develop --title "chore: promote develop -> main" --body "Promote integration branch to main"
+```
 
 ## Branch Strategy
 
-- **`main`**: Production-ready code only. Protected branch that requires PR approval.
-- **`develop`**: Active development branch. All features, hotfixes, and improvements go here.
-- **Feature branches**: Create from `develop` for new features (`feature/feature-name`)
-- **Hotfix branches**: Create from `develop` for urgent fixes (`hotfix/fix-name`)
-
-**Important**: Never work directly on `main`. All development work should be done on `develop` or feature branches created from `develop`.
+**Important**: Never work directly on `main`. All regular development work should be done on feature branches created from `develop` and merged into `develop` via pull requests. For emergency hotfixes, branch from `main`, open a PR to `main`, and then merge `main` back to `develop` to keep integration in sync.
 
 ## Code Style
 

--- a/docs/features/DEVELOPMENT_WORKFLOW.md
+++ b/docs/features/DEVELOPMENT_WORKFLOW.md
@@ -10,33 +10,32 @@ This document outlines the branch strategy and development workflow for the GitH
 
 - **Purpose**: Production-ready code only
 - **Protection**: Fully protected with branch protection rules
-- **Access**: No direct pushes allowed - only through approved PRs from `develop`
+- **Access**: No direct pushes allowed - only through approved PRs
 - **Deployment**: Automatically deploys to production environments
 - **Stability**: Should always be stable and deployable
 
-#### `develop` Branch
+#### `develop` Branch (Integration)
 
-- **Purpose**: Active development branch where all work happens
-- **Access**: All feature branches, hotfixes, and improvements merge here first
-- **Testing**: CI/CD runs full test suite on all commits
-- **Integration**: Integration point for all development work
-- **Releases**: Periodically merged to `main` for releases
+- **Purpose**: Integration branch for feature work and testing
+- **Access**: Feature branches target `develop` via PRs
+- **Testing**: CI/CD runs full test suite on `develop` for integration validation
+- **Integration**: Aggregates feature work prior to promotion to `main`
 
 ### Supporting Branches
 
 #### Feature Branches
 
 - **Naming**: `feature/feature-name` or `feature/issue-number-description`
-- **Source**: Created from `develop`
-- **Target**: Merged back to `develop` via PR
+  -- **Source**: Created from `develop`
+  -- **Target**: Merged back to `develop` via PR
 - **Lifecycle**: Deleted after successful merge
 - **Purpose**: Develop new features, enhancements, or improvements
 
 #### Hotfix Branches
 
 - **Naming**: `hotfix/issue-description` or `hotfix/issue-number`
-- **Source**: Created from `develop` (not `main`)
-- **Target**: Merged to `develop` via PR, then `develop` → `main` for urgent release
+- **Source**: Created from `main` (hotfixes are applied directly to production branch)
+- **Target**: Merged to `main` via PR, then `main` → `develop` to keep integration branch in sync
 - **Purpose**: Critical bug fixes that need immediate attention
 
 ## 🔄 Development Workflow
@@ -44,19 +43,20 @@ This document outlines the branch strategy and development workflow for the GitH
 ### 1. Starting New Work
 
 ```bash
-# Always start from develop
+# Always start from develop for regular feature work
 git checkout develop
 git pull origin develop
 
 # Create your working branch
 git checkout -b feature/your-feature-name
-# or for hotfixes:
-git checkout -b hotfix/critical-fix
+# or for hotfixes (branch from main):
+# git checkout -b hotfix/critical-fix main
 ```
 
 ### 2. During Development
 
 ```bash
+git commit -m "feat: implement new feature"
 # Make your changes
 git add .
 git commit -m "feat: implement new feature"
@@ -82,7 +82,7 @@ git push origin feature/your-feature-name
 ### 4. Release Process
 
 ```bash
-# When ready for release, create PR: develop → main
+# When ready for release, create PR: develop → main (maintainers) or tag a release from main
 # This triggers production deployment after approval
 ```
 
@@ -171,10 +171,10 @@ git push origin v1.2.0
 
 ## ❌ What NOT to Do
 
-- ❌ **Never work directly on `main`** - Always work on `develop` or feature branches
+- ❌ **Never work directly on `main`** - Always work on feature branches created from `develop` and merge to `develop` via PR
 - ❌ **Never force push to `main`** - It's protected anyway
-- ❌ **Never merge to `main` without PR** - Branch protection prevents this
-- ❌ **Never create feature branches from `main`** - Always use `develop` as base
+- ❌ **Never merge to `main` without PR** - Branch protection prevents this; use `develop` → `main` PRs for promotion
+- ✅ **Feature branches should be created from `develop` and kept up-to-date with `develop`**
 - ❌ **Never bypass code review** - All changes must go through PR process
 
 ## ✅ Best Practices
@@ -184,7 +184,7 @@ git push origin v1.2.0
 - ✅ **Write clear commit messages** - Follow conventional commits format
 - ✅ **Test before pushing** - Run tests locally before creating PR
 - ✅ **Keep PRs small** - Easier to review and less likely to have conflicts
-- ✅ **Update branch regularly** - Merge/rebase from `develop` frequently
+- ✅ **Update branch regularly** - Merge/rebase from `main` frequently
 - ✅ **Delete merged branches** - Keep repository clean
 
 ## 🔍 Monitoring and Maintenance

--- a/scripts/runner-self-test.sh
+++ b/scripts/runner-self-test.sh
@@ -37,7 +37,7 @@ if ! check_runner_registered; then
   exit 3
 fi
 
-gh workflow run ".github/workflows/$WORKFLOW_FILE" --repo "$GH_REPO" --ref develop
+gh workflow run ".github/workflows/$WORKFLOW_FILE" --repo "$GH_REPO" --ref main
 
 run_id=""
 for i in $(seq 1 60); do

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 # GitHub Branch Protection Setup Script
-# Sets up branch protection rules for main and develop branches
+# Sets up branch protection rules for main and develop branches (main is primary)
 
 # Color output for logging
 RED='\033[0;31m'
@@ -60,11 +60,11 @@ get_repo_info() {
 
 # Setup branch protection for develop branch
 setup_develop_protection() {
-    log_info "Setting up branch protection for 'develop' branch..."
+  log_info "Setting up branch protection for 'develop' branch (created from main if missing)..."
     
     # Check if develop branch exists
     if ! gh api repos/$REPO_OWNER/$REPO_NAME/branches/develop >/dev/null 2>&1; then
-        log_warning "The 'develop' branch does not exist. Creating it..."
+  log_warning "The 'develop' branch does not exist. Creating it from the repository default (usually main)..."
         
         # Create develop branch from main
         DEFAULT_BRANCH=$(gh repo view --json defaultBranch --jq .defaultBranch)
@@ -147,7 +147,7 @@ EOF
         fi
     fi
     
-    log_success "Branch protection configured for 'develop' branch"
+  log_success "Branch protection configured for 'develop' branch"
 }
 
 # Setup branch protection for main branch
@@ -255,7 +255,7 @@ show_protection_status() {
 
 # Main execution
 main() {
-    log_info "🛡️ Setting up GitHub branch protection rules..."
+  log_info "🛡️ Setting up GitHub branch protection rules (main is primary)..."
     
     check_gh_cli
     get_repo_info
@@ -271,7 +271,7 @@ main() {
     
     echo ""
     log_info "Branch protection rules configured:"
-    log_info "✓ Pull requests required for both main and develop branches"
+  log_info "✓ Pull requests required for both main and develop branches"
     if [ "$COPILOT_AUTO_MERGE" = true ]; then
         log_info "✓ No review requirement (Copilot auto-merge enabled)"
         log_info "✓ No conversation resolution required (Copilot friendly)"
@@ -284,7 +284,7 @@ main() {
     log_info "✓ Branch deletions blocked"
     
     echo ""
-    log_warning "Note: You may need admin permissions to modify some protection settings."
+  log_warning "Note: You may need admin permissions to modify some protection settings."
 }
 
 # Handle script arguments


### PR DESCRIPTION
Make user-deployment tests run on feature PRs targeting develop as well as promotion PRs from develop->main. This aligns the CI with the canonical branch flow: feature -> develop -> main.\n\nChecklist:\n- [ ] Run CI on this PR and verify user-deployment job triggers for a feature PR to develop\n- [ ] Confirm no unintended deploy triggers on main\n- [ ] Merge after approval\n\nNotes: Conservative change; no push trigger modifications were made.