### PR TITLE
fix: patch tar vulnerability

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,13 +58,16 @@ RUN set -e; \
         rm "./actions-runner.tar.gz"
 
 RUN set -e; \
-        for NODE_ROOT in /actions-runner/externals/node*/ ; do \
-            if [ -x "${NODE_ROOT}bin/node" ] && [ -d "${NODE_ROOT}lib/node_modules/npm" ]; then \
-                NPM_DIR="${NODE_ROOT}lib/node_modules/npm"; \
-                rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar"; \
-                "${NODE_ROOT}bin/node" "${NPM_DIR}/bin/npm-cli.js" install cross-spawn@${CROSS_SPAWN_VERSION} tar@${TAR_VERSION} --omit=dev --no-save --cache /tmp/npm-cache; \
-                rm -rf "${NPM_DIR}/node_modules/.npm" /tmp/npm-cache; \
-            fi; \
+    for NODE_ROOT in /actions-runner/externals/node*/ ; do \
+        if [ -x "${NODE_ROOT}bin/node" ] && [ -d "${NODE_ROOT}lib/node_modules/npm" ]; then \
+            NPM_DIR="${NODE_ROOT}lib/node_modules/npm"; \
+            PATCH_DIR="$(mktemp -d)"; \
+            printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" > "${PATCH_DIR}/package.json"; \
+            "${NODE_ROOT}bin/node" "${NPM_DIR}/bin/npm-cli.js" install --prefix="${PATCH_DIR}" --omit=dev --cache /tmp/npm-cache; \
+            rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar"; \
+            cp -a "${PATCH_DIR}/node_modules/." "${NPM_DIR}/node_modules/"; \
+            rm -rf "${PATCH_DIR}" "${NPM_DIR}/node_modules/.npm" /tmp/npm-cache; \
+    	fi; \
         done
 WORKDIR /home/runner
 

--- a/docker/Dockerfile.chrome
+++ b/docker/Dockerfile.chrome
@@ -143,13 +143,16 @@ RUN curl -o "actions-runner.tar.gz" -L "https://github.com/actions/runner/releas
 
 # --- PATCH EMBEDDED NODE DISTRIBUTIONS ---
 RUN for NODE_ROOT in /actions-runner/externals/node*/ ; do \
-            if [ -x "${NODE_ROOT}bin/node" ] && [ -d "${NODE_ROOT}lib/node_modules/npm" ]; then \
-                NPM_DIR="${NODE_ROOT}lib/node_modules/npm"; \
-                rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar"; \
-                "${NODE_ROOT}bin/node" "${NPM_DIR}/bin/npm-cli.js" install cross-spawn@${CROSS_SPAWN_VERSION} tar@${TAR_VERSION} --omit=dev --no-save --cache /tmp/npm-cache; \
-                rm -rf "${NPM_DIR}/node_modules/.npm" /tmp/npm-cache; \
-            fi; \
-        done
+    if [ -x "${NODE_ROOT}bin/node" ] && [ -d "${NODE_ROOT}lib/node_modules/npm" ]; then \
+        NPM_DIR="${NODE_ROOT}lib/node_modules/npm"; \
+        PATCH_DIR="$(mktemp -d)"; \
+        printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" > "${PATCH_DIR}/package.json"; \
+        "${NODE_ROOT}bin/node" "${NPM_DIR}/bin/npm-cli.js" install --prefix="${PATCH_DIR}" --omit=dev --cache /tmp/npm-cache; \
+        rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar"; \
+        cp -a "${PATCH_DIR}/node_modules/." "${NPM_DIR}/node_modules/"; \
+        rm -rf "${PATCH_DIR}" "${NPM_DIR}/node_modules/.npm" /tmp/npm-cache; \
+    fi; \
+done
 WORKDIR /home/runner
 
 # --- VERIFICATION, HEALTHCHECK AND ENTRYPOINT ---

--- a/docker/Dockerfile.chrome-go
+++ b/docker/Dockerfile.chrome-go
@@ -152,13 +152,16 @@ RUN curl -o "actions-runner.tar.gz" -L "https://github.com/actions/runner/releas
 
 # --- PATCH EMBEDDED NODE DISTRIBUTIONS ---
 RUN for NODE_ROOT in /actions-runner/externals/node*/ ; do \
-            if [ -x "${NODE_ROOT}bin/node" ] && [ -d "${NODE_ROOT}lib/node_modules/npm" ]; then \
-                NPM_DIR="${NODE_ROOT}lib/node_modules/npm"; \
-                rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar"; \
-                "${NODE_ROOT}bin/node" "${NPM_DIR}/bin/npm-cli.js" install cross-spawn@${CROSS_SPAWN_VERSION} tar@${TAR_VERSION} --omit=dev --no-save --cache /tmp/npm-cache; \
-                rm -rf "${NPM_DIR}/node_modules/.npm" /tmp/npm-cache; \
-            fi; \
-        done
+    if [ -x "${NODE_ROOT}bin/node" ] && [ -d "${NODE_ROOT}lib/node_modules/npm" ]; then \
+        NPM_DIR="${NODE_ROOT}lib/node_modules/npm"; \
+        PATCH_DIR="$(mktemp -d)"; \
+        printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" > "${PATCH_DIR}/package.json"; \
+        "${NODE_ROOT}bin/node" "${NPM_DIR}/bin/npm-cli.js" install --prefix="${PATCH_DIR}" --omit=dev --cache /tmp/npm-cache; \
+        rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar"; \
+        cp -a "${PATCH_DIR}/node_modules/." "${NPM_DIR}/node_modules/"; \
+        rm -rf "${PATCH_DIR}" "${NPM_DIR}/node_modules/.npm" /tmp/npm-cache; \
+    fi; \
+done
 WORKDIR /home/runner
 
 # --- VERIFICATION, HEALTHCHECK AND ENTRYPOINT ---


### PR DESCRIPTION
## Summary
- add TAR_VERSION args/env so runner images pin tar 7.5.2
- reinstall tar@7.5.2 alongside cross-spawn in embedded npm bundles
- align chrome/go variants with the same tar update to clear alert 4569

## Testing
- ./scripts/build.sh *(fails: interrupted at apt install, exit 130)*
