### PR TITLE
chore: merge main into develop

### DIFF
--- a/docker/Dockerfile.chrome-go
+++ b/docker/Dockerfile.chrome-go
@@ -165,9 +165,9 @@ RUN for NODE_ROOT in /actions-runner/externals/node*/ ; do \
     if [ -x "${NODE_ROOT}bin/node" ] && [ -d "${NODE_ROOT}lib/node_modules/npm" ]; then \
         NPM_DIR="${NODE_ROOT}lib/node_modules/npm"; \
         PATCH_DIR="$(mktemp -d)"; \
-        printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" > "${PATCH_DIR}/package.json"; \
+        printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s",\n    "brace-expansion": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" "${BRACE_EXPANSION_VERSION}" > "${PATCH_DIR}/package.json"; \
         "${NODE_ROOT}bin/node" "${NPM_DIR}/bin/npm-cli.js" install --prefix="${PATCH_DIR}" --omit=dev --cache /tmp/npm-cache; \
-        rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar"; \
+        rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar" "${NPM_DIR}/node_modules/brace-expansion"; \
         cp -a "${PATCH_DIR}/node_modules/." "${NPM_DIR}/node_modules/"; \
         rm -rf "${PATCH_DIR}" "${NPM_DIR}/node_modules/.npm" /tmp/npm-cache; \
     fi; \


### PR DESCRIPTION
## Summary
- merge latest main into develop to resolve conflicts blocking release PR #1023
- keep brace-expansion dependency patches across runner Dockerfiles
- update chrome-go runner to patch npm brace-expansion inside embedded node