### PR TITLE
fix: ensure npm bundles patched tar

### DIFF
--- a/docker/Dockerfile.chrome
+++ b/docker/Dockerfile.chrome
@@ -112,6 +112,17 @@ RUN curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-l
     && npm explore npm -g -- npm install cross-spawn@${CROSS_SPAWN_VERSION} tar@${TAR_VERSION} --omit=dev --package-lock=false \
     && npm cache clean --force
 
+RUN set -e; \
+    NPM_DIR="/usr/local/lib/node_modules/npm"; \
+    if [ -d "${NPM_DIR}/node_modules" ]; then \
+        PATCH_DIR="$(mktemp -d)"; \
+        printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s",\n    "brace-expansion": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" "${BRACE_EXPANSION_VERSION}" > "${PATCH_DIR}/package.json"; \
+        npm install --prefix="${PATCH_DIR}" --omit=dev --cache /tmp/npm-cache; \
+        rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar" "${NPM_DIR}/node_modules/brace-expansion"; \
+        cp -a "${PATCH_DIR}/node_modules/." "${NPM_DIR}/node_modules/"; \
+        rm -rf "${PATCH_DIR}" "${NPM_DIR}/node_modules/.npm" /tmp/npm-cache; \
+    fi
+
 # --- INSTALL PYTHON PACKAGES ---
 USER runner
 WORKDIR /home/runner

--- a/docker/Dockerfile.chrome-go
+++ b/docker/Dockerfile.chrome-go
@@ -112,6 +112,17 @@ RUN curl -fsSL "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-l
     && npm explore npm -g -- npm install cross-spawn@${CROSS_SPAWN_VERSION} tar@${TAR_VERSION} --omit=dev --package-lock=false \
     && npm cache clean --force
 
+RUN set -e; \
+    NPM_DIR="/usr/local/lib/node_modules/npm"; \
+    if [ -d "${NPM_DIR}/node_modules" ]; then \
+        PATCH_DIR="$(mktemp -d)"; \
+        printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s",\n    "brace-expansion": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" "${BRACE_EXPANSION_VERSION}" > "${PATCH_DIR}/package.json"; \
+        npm install --prefix="${PATCH_DIR}" --omit=dev --cache /tmp/npm-cache; \
+        rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar" "${NPM_DIR}/node_modules/brace-expansion"; \
+        cp -a "${PATCH_DIR}/node_modules/." "${NPM_DIR}/node_modules/"; \
+        rm -rf "${PATCH_DIR}" "${NPM_DIR}/node_modules/.npm" /tmp/npm-cache; \
+    fi
+
 # --- INSTALL GO ---
 RUN GO_VERSION="1.25.4" \
     && curl -fsSL "https://golang.org/dl/go${GO_VERSION}.linux-amd64.tar.gz" -o /tmp/go.tar.gz \


### PR DESCRIPTION
## Summary
- patch npm's bundled node_modules to receive tar@
- mirror the update across chrome and chrome-go runner images
- clean up temporary patch directories to keep image lean

## Testing
- ./tests/docker/validate-packages.sh