### PR TITLE
fix(ci): resolve multi-platform build error in Trivy SARIF workflow

### DIFF
--- a/.github/workflows/seed-trivy-sarif.yml
+++ b/.github/workflows/seed-trivy-sarif.yml
@@ -46,7 +46,7 @@ jobs:
           timeout: "10m"
 
       - name: Upload Trivy filesystem SARIF to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: "trivy-filesystem-baseline.sarif"
@@ -74,44 +74,35 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Set up QEMU for multi-platform builds
-        uses: docker/setup-qemu-action@v3
-        if: matrix.variant == 'standard'
-        with:
-          platforms: linux/amd64,linux/arm64
-
       - name: Build Docker image for scanning
         uses: docker/build-push-action@v6
         with:
           context: ./docker
           file: ./docker/Dockerfile${{ matrix.variant == 'standard' && '' || format('.{0}', matrix.variant) }}
-          platforms: ${{ matrix.variant == 'standard' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          platforms: linux/amd64
           tags: github-runner-${{ matrix.variant }}:scan
-          load: false
+          load: true
           push: false
           cache-from: |
             type=gha
             type=gha,scope=${{ matrix.variant == 'standard' && 'normal' || matrix.variant }}-runner
             type=gha,scope=buildcache
-          outputs: type=docker,dest=/tmp/github-runner-${{ matrix.variant }}.tar
 
-      - name: Load image for scanning
-        run: |
-          docker load --input /tmp/github-runner-${{ matrix.variant }}.tar
-          docker images
+      - name: Verify image loaded
+        run: docker images | grep github-runner-${{ matrix.variant }}
 
       - name: Run Trivy container scan (generate SARIF)
         uses: aquasecurity/trivy-action@0.28.0
         with:
           scan-type: "image"
-          input: /tmp/github-runner-${{ matrix.variant }}.tar
+          image-ref: github-runner-${{ matrix.variant }}:scan
           format: "sarif"
           output: "trivy-container-${{ matrix.variant }}-baseline.sarif"
           severity: "CRITICAL,HIGH,MEDIUM"
           timeout: "15m"
 
       - name: Upload Trivy container SARIF to GitHub Code Scanning
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         if: always()
         with:
           sarif_file: "trivy-container-${{ matrix.variant }}-baseline.sarif"


### PR DESCRIPTION
## Summary
Fixes GitHub Actions run #19409966660 which was failing with:
`ERROR: docker exporter does not support exporting manifest lists, use the oci exporter instead`

## Changes
- Removed multi-platform build for security scanning (only need linux/amd64)
- Removed QEMU setup (not needed for single platform)
- Changed from docker export to direct image load
- Updated Trivy scan to use image-ref instead of tar input
- Upgraded CodeQL Action from v3 to v4 (deprecation fix)

## Root Cause
The workflow was attempting to build multi-platform images (linux/amd64,linux/arm64) and export them using the docker exporter (type=docker,dest=...), which doesn't support manifest lists.

## Solution
For security scanning, we only need to scan one platform. Multi-platform builds are handled in the release workflow.

## Testing
- [x] Workflow syntax validated
- [ ] Will verify in CI/CD pipeline after PR creation
