### PR TITLE
fix(ci): correct Dockerfile path expression for standard variant

### DIFF
--- a/.github/workflows/seed-trivy-sarif.yml
+++ b/.github/workflows/seed-trivy-sarif.yml
@@ -78,7 +78,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: ./docker
-          file: ./docker/Dockerfile${{ matrix.variant == 'standard' && '' || format('.{0}', matrix.variant) }}
+          file: ./docker/${{ matrix.variant == 'standard' && 'Dockerfile' || format('Dockerfile.{0}', matrix.variant) }}
           platforms: linux/amd64
           tags: github-runner-${{ matrix.variant }}:scan
           load: true


### PR DESCRIPTION
## Summary
Fixes the Dockerfile path for the standard variant in the Trivy SARIF workflow.

## Problem
Run 19410124529 failed with:
`ERROR: failed to build: failed to read dockerfile: open Dockerfile.standard: no such file or directory`

The expression `Dockerfile${{ matrix.variant == 'standard' && '' || format('.{0}', matrix.variant) }}` was incorrectly evaluating to `Dockerfile.standard` instead of just `Dockerfile`.

## Solution
Changed the expression to explicitly return the full filename:
- `${{ matrix.variant == 'standard' && 'Dockerfile' || format('Dockerfile.{0}', matrix.variant) }}`

This ensures:
- standard variant → `./docker/Dockerfile` ✅
- chrome variant → `./docker/Dockerfile.chrome` ✅
- chrome-go variant → `./docker/Dockerfile.chrome-go` ✅

## Testing
- [x] Expression logic verified
- [ ] Will verify in CI/CD after PR creation