### PR TITLE
fix(security): upgrade Go to 1.25.5 to fix CVE-2025-61729

### DIFF
--- a/docker/Dockerfile.chrome-go
+++ b/docker/Dockerfile.chrome-go
@@ -151,7 +151,7 @@ RUN --mount=type=cache,target=/tmp/npm-cache,uid=0,gid=0 \
 # Use BuildKit cache for Go download
 # Go supports both amd64 and arm64 architectures
 RUN --mount=type=cache,target=/tmp/downloads \
-    GO_VERSION="1.25.4" \
+    GO_VERSION="1.25.5" \
     && case ${TARGETARCH} in \
         "amd64")  GO_ARCH="amd64"  ;; \
         "arm64")  GO_ARCH="arm64"  ;; \


### PR DESCRIPTION
## 📋 Pull Request Description

### 🔀 Merge Strategy

**This repository uses SQUASH MERGE as the standard merge strategy.**

### Summary

This PR fixes CVE-2025-61729, a HIGH severity security vulnerability in Go's standard library affecting version 1.25.4. This is a focused security fix with minimal changes.

### Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] 🔒 Security enhancement

### Related Issues

- Fixes https://github.com/GrammaTonic/github-runner/security/code-scanning/5682

## 🔄 Changes Made

### Files Modified

- [x] `docker/Dockerfile.chrome-go` - Updated Go version from 1.25.4 to 1.25.5 (1 line change)

### Key Changes

1. Upgraded Go from version 1.25.4 to 1.25.5 in Chrome-Go runner Dockerfile
2. Resolves CVE-2025-61729 - HIGH severity vulnerability in stdlib
3. Prevents excessive resource consumption from malicious certificates
4. Fixes quadratic runtime issue in HostnameError.Error() error string construction

### Vulnerability Details

- **CVE ID**: CVE-2025-61729
- **Severity**: HIGH
- **Affected Package**: Go stdlib 1.25.4
- **Fixed Versions**: 1.24.11, 1.25.5
- **Issue**: Within HostnameError.Error(), when constructing an error string, there is no limit to the number of hosts that will be printed out. Furthermore, the error string is constructed by repeated string concatenation, leading to quadratic runtime. A certificate provided by a malicious actor can result in excessive resource consumption.
- **Link**: https://avd.aquasec.com/nvd/cve-2025-61729

## 🧪 Testing

### Testing Performed

- [x] Docker build will be validated by CI/CD pipeline
- [x] Trivy security scanning will verify vulnerability is resolved
- [x] All automated tests will run via GitHub Actions

### Test Coverage

- [x] Security scanning will validate the fix
- [x] Existing tests cover Chrome-Go runner functionality

## 🔒 Security Considerations

- [x] No new security vulnerabilities introduced
- [x] Fixes HIGH severity CVE-2025-61729
- [x] Container security best practices followed
- [x] Minimal change (1 line) reduces risk

## 📚 Documentation

- [x] Security fix documented in commit message
- [x] CVE details included in PR description

## 🚀 Deployment Notes

- [x] Docker image rebuild required for Chrome-Go runner
- [x] No configuration changes needed
- [x] No environment variable updates required

## ✅ Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Security vulnerability has been addressed
- [x] Change is minimal and focused (1 line change)

---

**Note for Reviewers:**

This is a critical security fix that should be merged and deployed promptly. The change is minimal (single line) and low-risk, upgrading Go to the patched version that resolves CVE-2025-61729. This PR contains ONLY the security fix, unlike PR #1072 which inadvertently included unrelated changes.