### PR TITLE
fix: address Gemini feedback for PR #1090

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,6 +63,13 @@ RUN --mount=type=cache,target=/tmp/downloads,uid=1001,gid=1001 \
 # --- PATCH EMBEDDED NODE DISTRIBUTIONS IN BUILDER ---
 RUN --mount=type=cache,target=/tmp/npm-cache,uid=1001,gid=1001 \
     set -e; \
+    validate_semver() { \
+        printf '%s' "$1" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; \
+    }; \
+    validate_semver "${CROSS_SPAWN_VERSION}" || { echo "Invalid CROSS_SPAWN_VERSION: ${CROSS_SPAWN_VERSION}"; exit 1; }; \
+    validate_semver "${TAR_VERSION}" || { echo "Invalid TAR_VERSION: ${TAR_VERSION}"; exit 1; }; \
+    validate_semver "${BRACE_EXPANSION_VERSION}" || { echo "Invalid BRACE_EXPANSION_VERSION: ${BRACE_EXPANSION_VERSION}"; exit 1; }; \
+    validate_semver "${GLOB_VERSION}" || { echo "Invalid GLOB_VERSION: ${GLOB_VERSION}"; exit 1; }; \
     for NODE_ROOT in /actions-runner/externals/node*/ ; do \
         if [ -x "${NODE_ROOT}bin/node" ] && [ -d "${NODE_ROOT}lib/node_modules/npm" ]; then \
             NPM_DIR="${NODE_ROOT}lib/node_modules/npm"; \

--- a/docker/entrypoint-chrome.sh
+++ b/docker/entrypoint-chrome.sh
@@ -56,6 +56,27 @@ METRICS_PORT="${METRICS_PORT:-9091}"
 METRICS_FILE="${METRICS_FILE:-/tmp/runner_metrics.prom}"
 RUNNER_TYPE="${RUNNER_TYPE:-chrome}"
 
+case "${METRICS_FILE}" in
+	/tmp/*.prom) ;;
+	*)
+		echo "Error: METRICS_FILE must be under /tmp and end with .prom"
+		exit 1
+		;;
+esac
+
+case "${JOBS_LOG}" in
+	/tmp/*.log) ;;
+	*)
+		echo "Error: JOBS_LOG must be under /tmp and end with .log"
+		exit 1
+		;;
+esac
+
+if [[ "${METRICS_FILE}" == *".."* ]] || [[ "${JOBS_LOG}" == *".."* ]]; then
+	echo "Error: Path traversal is not allowed in metrics paths"
+	exit 1
+fi
+
 echo "Starting Prometheus metrics services..."
 echo "  - Metrics endpoint: http://localhost:${METRICS_PORT}/metrics"
 echo "  - Runner type: ${RUNNER_TYPE}"

--- a/docs/features/GRAFANA_DASHBOARD_METRICS.md
+++ b/docs/features/GRAFANA_DASHBOARD_METRICS.md
@@ -205,7 +205,7 @@ PORT="${METRICS_PORT:-9091}"
 
 while true; do
     # Wait for connection
-    RESPONSE=$(echo -e "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4\r\n\r\n$(cat \"$METRICS_FILE\" 2>/dev/null || echo '# No metrics available')" | nc -l -p "$PORT" -q 1)
+   echo -e "HTTP/1.1 200 OK\r\nContent-Type: text/plain; version=0.0.4\r\n\r\n$(cat \"$METRICS_FILE\" 2>/dev/null || echo '# No metrics available')" | nc -l -p "$PORT" -q 1
 done
 ```
 

--- a/docs/features/PHASE2_IMPLEMENTATION_SUMMARY.md
+++ b/docs/features/PHASE2_IMPLEMENTATION_SUMMARY.md
@@ -111,13 +111,13 @@ All five core metrics from Phase 1 are available for Chrome and Chrome-Go runner
 
 1. **github_runner_status** (gauge)
    - Values: 1=online, 0=offline
-   - Labels: none
+   - Labels: runner_name, runner_type
 
 2. **github_runner_info** (gauge)
    - Value: always 1
    - Labels: runner_name, runner_type (chrome/chrome-go), version
 
-3. **github_runner_uptime_seconds** (counter)
+3. **github_runner_uptime_seconds** (gauge)
    - Tracks runner uptime since start
    - Updates every 30 seconds
 


### PR DESCRIPTION
Addresses Gemini review findings from PR #1090:\n\n- Validate build ARG versions before generating package JSON in docker/Dockerfile\n- Restrict and validate METRICS_FILE/JOBS_LOG paths in docker/entrypoint-chrome.sh\n- Correct metrics documentation (uptime type and status labels)\n- Remove unused RESPONSE assignment in metrics-server doc example\n\nThis is a focused follow-up to unblock promotion PR checks and security review.