### PR TITLE
fix: resolve develop branch code-scanning findings

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,9 +11,12 @@ ARG TARGETARCH
 ARG TARGETOS
 ARG RUNNER_VERSION="2.331.0"
 ARG CROSS_SPAWN_VERSION="7.0.6"
-ARG TAR_VERSION="7.5.4"
+ARG TAR_VERSION="7.5.6"
 ARG BRACE_EXPANSION_VERSION="2.0.2"
+ARG ISAACS_BRACE_EXPANSION_VERSION="5.0.0"
 ARG GLOB_VERSION="13.0.0"
+ARG MINIMATCH_VERSION="10.1.1"
+ARG DIFF_VERSION="8.0.2"
 
 # --- ENVIRONMENT VARIABLES ---
 ENV DEBIAN_FRONTEND=noninteractive
@@ -69,14 +72,17 @@ RUN --mount=type=cache,target=/tmp/npm-cache,uid=1001,gid=1001 \
     validate_semver "${CROSS_SPAWN_VERSION}" || { echo "Invalid CROSS_SPAWN_VERSION: ${CROSS_SPAWN_VERSION}"; exit 1; }; \
     validate_semver "${TAR_VERSION}" || { echo "Invalid TAR_VERSION: ${TAR_VERSION}"; exit 1; }; \
     validate_semver "${BRACE_EXPANSION_VERSION}" || { echo "Invalid BRACE_EXPANSION_VERSION: ${BRACE_EXPANSION_VERSION}"; exit 1; }; \
+    validate_semver "${ISAACS_BRACE_EXPANSION_VERSION}" || { echo "Invalid ISAACS_BRACE_EXPANSION_VERSION: ${ISAACS_BRACE_EXPANSION_VERSION}"; exit 1; }; \
     validate_semver "${GLOB_VERSION}" || { echo "Invalid GLOB_VERSION: ${GLOB_VERSION}"; exit 1; }; \
+    validate_semver "${MINIMATCH_VERSION}" || { echo "Invalid MINIMATCH_VERSION: ${MINIMATCH_VERSION}"; exit 1; }; \
+    validate_semver "${DIFF_VERSION}" || { echo "Invalid DIFF_VERSION: ${DIFF_VERSION}"; exit 1; }; \
     for NODE_ROOT in /actions-runner/externals/node*/ ; do \
         if [ -x "${NODE_ROOT}bin/node" ] && [ -d "${NODE_ROOT}lib/node_modules/npm" ]; then \
             NPM_DIR="${NODE_ROOT}lib/node_modules/npm"; \
             PATCH_DIR="$(mktemp -d)"; \
-            printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s",\n    "brace-expansion": "%s",\n    "glob": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" "${BRACE_EXPANSION_VERSION}" "${GLOB_VERSION}" > "${PATCH_DIR}/package.json"; \
+            printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s",\n    "brace-expansion": "%s",\n    "@isaacs/brace-expansion": "%s",\n    "glob": "%s",\n    "minimatch": "%s",\n    "diff": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" "${BRACE_EXPANSION_VERSION}" "${ISAACS_BRACE_EXPANSION_VERSION}" "${GLOB_VERSION}" "${MINIMATCH_VERSION}" "${DIFF_VERSION}" > "${PATCH_DIR}/package.json"; \
             "${NODE_ROOT}bin/node" "${NPM_DIR}/bin/npm-cli.js" install --prefix="${PATCH_DIR}" --omit=dev --cache /tmp/npm-cache; \
-            rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar" "${NPM_DIR}/node_modules/brace-expansion" "${NPM_DIR}/node_modules/glob"; \
+            rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar" "${NPM_DIR}/node_modules/brace-expansion" "${NPM_DIR}/node_modules/@isaacs/brace-expansion" "${NPM_DIR}/node_modules/glob" "${NPM_DIR}/node_modules/minimatch" "${NPM_DIR}/node_modules/diff"; \
             cp -a "${PATCH_DIR}/node_modules/." "${NPM_DIR}/node_modules/"; \
             rm -rf "${PATCH_DIR}" "${NPM_DIR}/node_modules/.npm"; \
         fi; \
@@ -94,13 +100,19 @@ LABEL version="2.2.0"
 ARG TARGETARCH
 ARG RUNNER_VERSION="2.331.0"
 ARG CROSS_SPAWN_VERSION="7.0.6"
-ARG TAR_VERSION="7.5.4"
+ARG TAR_VERSION="7.5.6"
 ARG BRACE_EXPANSION_VERSION="2.0.2"
+ARG ISAACS_BRACE_EXPANSION_VERSION="5.0.0"
+ARG MINIMATCH_VERSION="10.1.1"
+ARG DIFF_VERSION="8.0.2"
 
 ENV RUNNER_VERSION=${RUNNER_VERSION}
 ENV CROSS_SPAWN_VERSION=${CROSS_SPAWN_VERSION}
 ENV TAR_VERSION=${TAR_VERSION}
 ENV BRACE_EXPANSION_VERSION=${BRACE_EXPANSION_VERSION}
+ENV ISAACS_BRACE_EXPANSION_VERSION=${ISAACS_BRACE_EXPANSION_VERSION}
+ENV MINIMATCH_VERSION=${MINIMATCH_VERSION}
+ENV DIFF_VERSION=${DIFF_VERSION}
 ENV DEBIAN_FRONTEND=noninteractive
 
 # Set SHELL to handle pipe errors correctly

--- a/docker/Dockerfile.chrome
+++ b/docker/Dockerfile.chrome
@@ -25,9 +25,12 @@ ARG NPM_VERSION="11.6.4"
 ARG PLAYWRIGHT_VERSION="1.55.1"
 ARG PLAYWRIGHT_TEST_VERSION="1.55.1"
 ARG CROSS_SPAWN_VERSION="7.0.6"
-ARG TAR_VERSION="7.5.4"
+ARG TAR_VERSION="7.5.6"
 ARG BRACE_EXPANSION_VERSION="2.0.2"
+ARG ISAACS_BRACE_EXPANSION_VERSION="5.0.0"
 ARG GLOB_VERSION="13.0.0"
+ARG MINIMATCH_VERSION="10.1.1"
+ARG DIFF_VERSION="8.0.2"
 
 # Environment variables
 ENV DEBIAN_FRONTEND=noninteractive
@@ -45,6 +48,9 @@ ENV PLAYWRIGHT_TEST_VERSION=${PLAYWRIGHT_TEST_VERSION}
 ENV CROSS_SPAWN_VERSION=${CROSS_SPAWN_VERSION}
 ENV TAR_VERSION=${TAR_VERSION}
 ENV BRACE_EXPANSION_VERSION=${BRACE_EXPANSION_VERSION}
+ENV ISAACS_BRACE_EXPANSION_VERSION=${ISAACS_BRACE_EXPANSION_VERSION}
+ENV MINIMATCH_VERSION=${MINIMATCH_VERSION}
+ENV DIFF_VERSION=${DIFF_VERSION}
 
 # Set SHELL to handle pipe errors correctly
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -129,16 +135,16 @@ RUN --mount=type=cache,target=/tmp/downloads \
     && tar -xJf /tmp/downloads/node-v${NODE_VERSION}-linux-x64.tar.xz -C /usr/local --strip-components=1 --no-same-owner \
     && npm install -g npm@${NPM_VERSION} \
     && npm install -g cross-spawn@${CROSS_SPAWN_VERSION} tar@${TAR_VERSION} \
-    && npm explore npm -g -- npm install cross-spawn@${CROSS_SPAWN_VERSION} tar@${TAR_VERSION} --omit=dev --package-lock=false \
+    && npm explore npm -g -- npm install cross-spawn@${CROSS_SPAWN_VERSION} tar@${TAR_VERSION} @isaacs/brace-expansion@${ISAACS_BRACE_EXPANSION_VERSION} minimatch@${MINIMATCH_VERSION} diff@${DIFF_VERSION} --omit=dev --package-lock=false \
     && npm cache clean --force
 
 RUN set -e; \
     NPM_DIR="/usr/local/lib/node_modules/npm"; \
     if [ -d "${NPM_DIR}/node_modules" ]; then \
         PATCH_DIR="$(mktemp -d)"; \
-        printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s",\n    "brace-expansion": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" "${BRACE_EXPANSION_VERSION}" > "${PATCH_DIR}/package.json"; \
+        printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s",\n    "brace-expansion": "%s",\n    "@isaacs/brace-expansion": "%s",\n    "minimatch": "%s",\n    "diff": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" "${BRACE_EXPANSION_VERSION}" "${ISAACS_BRACE_EXPANSION_VERSION}" "${MINIMATCH_VERSION}" "${DIFF_VERSION}" > "${PATCH_DIR}/package.json"; \
         npm install --prefix="${PATCH_DIR}" --omit=dev --cache /tmp/npm-cache; \
-        rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar" "${NPM_DIR}/node_modules/brace-expansion"; \
+        rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar" "${NPM_DIR}/node_modules/brace-expansion" "${NPM_DIR}/node_modules/@isaacs/brace-expansion" "${NPM_DIR}/node_modules/minimatch" "${NPM_DIR}/node_modules/diff"; \
         cp -a "${PATCH_DIR}/node_modules/." "${NPM_DIR}/node_modules/"; \
         rm -rf "${PATCH_DIR}" "${NPM_DIR}/node_modules/.npm" /tmp/npm-cache; \
     fi
@@ -162,14 +168,17 @@ RUN --mount=type=cache,target=/home/runner/.npm-cache,uid=1001,gid=1001 \
         cross-spawn@${CROSS_SPAWN_VERSION} \
         tar@${TAR_VERSION} \
         brace-expansion@${BRACE_EXPANSION_VERSION} \
+        @isaacs/brace-expansion@${ISAACS_BRACE_EXPANSION_VERSION} \
+        minimatch@${MINIMATCH_VERSION} \
+        diff@${DIFF_VERSION} \
         playwright@${PLAYWRIGHT_VERSION} \
         @playwright/test@${PLAYWRIGHT_TEST_VERSION} \
         cypress@13.15.0; \
     PATCH_DIR="$(mktemp -d)"; \
-    printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s",\n    "brace-expansion": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" "${BRACE_EXPANSION_VERSION}" > "${PATCH_DIR}/package.json"; \
+    printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s",\n    "brace-expansion": "%s",\n    "@isaacs/brace-expansion": "%s",\n    "minimatch": "%s",\n    "diff": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" "${BRACE_EXPANSION_VERSION}" "${ISAACS_BRACE_EXPANSION_VERSION}" "${MINIMATCH_VERSION}" "${DIFF_VERSION}" > "${PATCH_DIR}/package.json"; \
     npm install --prefix="${PATCH_DIR}" --omit=dev --cache /home/runner/.npm-cache; \
     NPM_GLOBAL_DIR="/home/runner/.npm/lib/node_modules/npm/node_modules"; \
-    rm -rf "${NPM_GLOBAL_DIR}/cross-spawn" "${NPM_GLOBAL_DIR}/tar" "${NPM_GLOBAL_DIR}/brace-expansion"; \
+    rm -rf "${NPM_GLOBAL_DIR}/cross-spawn" "${NPM_GLOBAL_DIR}/tar" "${NPM_GLOBAL_DIR}/brace-expansion" "${NPM_GLOBAL_DIR}/@isaacs/brace-expansion" "${NPM_GLOBAL_DIR}/minimatch" "${NPM_GLOBAL_DIR}/diff"; \
     cp -a "${PATCH_DIR}/node_modules/." "${NPM_GLOBAL_DIR}/"; \
     rm -rf "${PATCH_DIR}" "${NPM_GLOBAL_DIR}/.npm" /home/runner/.cache/Cypress; \
     npm install playwright@${PLAYWRIGHT_VERSION}; \
@@ -200,9 +209,9 @@ RUN --mount=type=cache,target=/tmp/npm-cache,uid=1001,gid=1001 \
     if [ -x "${NODE_ROOT}bin/node" ] && [ -d "${NODE_ROOT}lib/node_modules/npm" ]; then \
         NPM_DIR="${NODE_ROOT}lib/node_modules/npm"; \
         PATCH_DIR="$(mktemp -d)"; \
-        printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s",\n    "brace-expansion": "%s",\n    "glob": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" "${BRACE_EXPANSION_VERSION}" "${GLOB_VERSION}" > "${PATCH_DIR}/package.json"; \
+        printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s",\n    "brace-expansion": "%s",\n    "@isaacs/brace-expansion": "%s",\n    "glob": "%s",\n    "minimatch": "%s",\n    "diff": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" "${BRACE_EXPANSION_VERSION}" "${ISAACS_BRACE_EXPANSION_VERSION}" "${GLOB_VERSION}" "${MINIMATCH_VERSION}" "${DIFF_VERSION}" > "${PATCH_DIR}/package.json"; \
         "${NODE_ROOT}bin/node" "${NPM_DIR}/bin/npm-cli.js" install --prefix="${PATCH_DIR}" --omit=dev --cache /tmp/npm-cache; \
-        rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar" "${NPM_DIR}/node_modules/brace-expansion" "${NPM_DIR}/node_modules/glob"; \
+        rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar" "${NPM_DIR}/node_modules/brace-expansion" "${NPM_DIR}/node_modules/@isaacs/brace-expansion" "${NPM_DIR}/node_modules/glob" "${NPM_DIR}/node_modules/minimatch" "${NPM_DIR}/node_modules/diff"; \
         cp -a "${PATCH_DIR}/node_modules/." "${NPM_DIR}/node_modules/"; \
         rm -rf "${PATCH_DIR}" "${NPM_DIR}/node_modules/.npm"; \
     fi; \

--- a/docker/Dockerfile.chrome-go
+++ b/docker/Dockerfile.chrome-go
@@ -26,9 +26,12 @@ ARG NPM_VERSION="11.6.4"
 ARG PLAYWRIGHT_VERSION="1.55.1"
 ARG PLAYWRIGHT_TEST_VERSION="1.55.1"
 ARG CROSS_SPAWN_VERSION="7.0.6"
-ARG TAR_VERSION="7.5.4"
+ARG TAR_VERSION="7.5.6"
 ARG BRACE_EXPANSION_VERSION="2.0.2"
+ARG ISAACS_BRACE_EXPANSION_VERSION="5.0.0"
 ARG GLOB_VERSION="13.0.0"
+ARG MINIMATCH_VERSION="10.1.1"
+ARG DIFF_VERSION="8.0.2"
 
 # Environment variables
 ENV DEBIAN_FRONTEND=noninteractive
@@ -46,6 +49,9 @@ ENV PLAYWRIGHT_TEST_VERSION=${PLAYWRIGHT_TEST_VERSION}
 ENV CROSS_SPAWN_VERSION=${CROSS_SPAWN_VERSION}
 ENV TAR_VERSION=${TAR_VERSION}
 ENV BRACE_EXPANSION_VERSION=${BRACE_EXPANSION_VERSION}
+ENV ISAACS_BRACE_EXPANSION_VERSION=${ISAACS_BRACE_EXPANSION_VERSION}
+ENV MINIMATCH_VERSION=${MINIMATCH_VERSION}
+ENV DIFF_VERSION=${DIFF_VERSION}
 
 # Set SHELL to handle pipe errors correctly
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
@@ -136,7 +142,7 @@ RUN --mount=type=cache,target=/tmp/downloads \
     && tar -xJf /tmp/downloads/node-v${NODE_VERSION}-linux-${NODE_ARCH}.tar.xz -C /usr/local --strip-components=1 --no-same-owner \
     && npm install -g npm@${NPM_VERSION} \
     && npm install -g cross-spawn@${CROSS_SPAWN_VERSION} tar@${TAR_VERSION} \
-    && npm explore npm -g -- npm install cross-spawn@${CROSS_SPAWN_VERSION} tar@${TAR_VERSION} --omit=dev --package-lock=false \
+    && npm explore npm -g -- npm install cross-spawn@${CROSS_SPAWN_VERSION} tar@${TAR_VERSION} @isaacs/brace-expansion@${ISAACS_BRACE_EXPANSION_VERSION} minimatch@${MINIMATCH_VERSION} diff@${DIFF_VERSION} --omit=dev --package-lock=false \
     && npm cache clean --force
 
 RUN --mount=type=cache,target=/tmp/npm-cache,uid=0,gid=0 \
@@ -144,9 +150,9 @@ RUN --mount=type=cache,target=/tmp/npm-cache,uid=0,gid=0 \
     NPM_DIR="/usr/local/lib/node_modules/npm"; \
     if [ -d "${NPM_DIR}/node_modules" ]; then \
         PATCH_DIR="$(mktemp -d)"; \
-        printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s",\n    "brace-expansion": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" "${BRACE_EXPANSION_VERSION}" > "${PATCH_DIR}/package.json"; \
+        printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s",\n    "brace-expansion": "%s",\n    "@isaacs/brace-expansion": "%s",\n    "minimatch": "%s",\n    "diff": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" "${BRACE_EXPANSION_VERSION}" "${ISAACS_BRACE_EXPANSION_VERSION}" "${MINIMATCH_VERSION}" "${DIFF_VERSION}" > "${PATCH_DIR}/package.json"; \
         npm install --prefix="${PATCH_DIR}" --omit=dev --cache /tmp/npm-cache; \
-        rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar" "${NPM_DIR}/node_modules/brace-expansion"; \
+        rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar" "${NPM_DIR}/node_modules/brace-expansion" "${NPM_DIR}/node_modules/@isaacs/brace-expansion" "${NPM_DIR}/node_modules/minimatch" "${NPM_DIR}/node_modules/diff"; \
         cp -a "${PATCH_DIR}/node_modules/." "${NPM_DIR}/node_modules/"; \
         rm -rf "${PATCH_DIR}" "${NPM_DIR}/node_modules/.npm"; \
     fi
@@ -155,7 +161,7 @@ RUN --mount=type=cache,target=/tmp/npm-cache,uid=0,gid=0 \
 # Use BuildKit cache for Go download
 # Go supports both amd64 and arm64 architectures
 RUN --mount=type=cache,target=/tmp/downloads \
-    GO_VERSION="1.25.5" \
+    GO_VERSION="1.25.7" \
     && case "${TARGETARCH}" in \
         "amd64")  GO_ARCH="amd64"  ;; \
         "arm64")  GO_ARCH="arm64"  ;; \
@@ -188,14 +194,17 @@ RUN --mount=type=cache,target=/home/runner/.npm-cache,uid=1001,gid=1001 \
         cross-spawn@${CROSS_SPAWN_VERSION} \
         tar@${TAR_VERSION} \
         brace-expansion@${BRACE_EXPANSION_VERSION} \
+        @isaacs/brace-expansion@${ISAACS_BRACE_EXPANSION_VERSION} \
+        minimatch@${MINIMATCH_VERSION} \
+        diff@${DIFF_VERSION} \
         playwright@${PLAYWRIGHT_VERSION} \
         @playwright/test@${PLAYWRIGHT_TEST_VERSION} \
         cypress@13.15.0; \
     PATCH_DIR="$(mktemp -d)"; \
-    printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s",\n    "brace-expansion": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" "${BRACE_EXPANSION_VERSION}" > "${PATCH_DIR}/package.json"; \
+    printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s",\n    "brace-expansion": "%s",\n    "@isaacs/brace-expansion": "%s",\n    "minimatch": "%s",\n    "diff": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" "${BRACE_EXPANSION_VERSION}" "${ISAACS_BRACE_EXPANSION_VERSION}" "${MINIMATCH_VERSION}" "${DIFF_VERSION}" > "${PATCH_DIR}/package.json"; \
     npm install --prefix="${PATCH_DIR}" --omit=dev --cache /home/runner/.npm-cache; \
     NPM_GLOBAL_DIR="/home/runner/.npm/lib/node_modules/npm/node_modules"; \
-    rm -rf "${NPM_GLOBAL_DIR}/cross-spawn" "${NPM_GLOBAL_DIR}/tar" "${NPM_GLOBAL_DIR}/brace-expansion"; \
+    rm -rf "${NPM_GLOBAL_DIR}/cross-spawn" "${NPM_GLOBAL_DIR}/tar" "${NPM_GLOBAL_DIR}/brace-expansion" "${NPM_GLOBAL_DIR}/@isaacs/brace-expansion" "${NPM_GLOBAL_DIR}/minimatch" "${NPM_GLOBAL_DIR}/diff"; \
     cp -a "${PATCH_DIR}/node_modules/." "${NPM_GLOBAL_DIR}/"; \
     rm -rf "${PATCH_DIR}" "${NPM_GLOBAL_DIR}/.npm" /home/runner/.cache/Cypress; \
     npm install playwright@${PLAYWRIGHT_VERSION}; \
@@ -232,9 +241,9 @@ RUN --mount=type=cache,target=/tmp/npm-cache,uid=1001,gid=1001 \
     if [ -x "${NODE_ROOT}bin/node" ] && [ -d "${NODE_ROOT}lib/node_modules/npm" ]; then \
         NPM_DIR="${NODE_ROOT}lib/node_modules/npm"; \
         PATCH_DIR="$(mktemp -d)"; \
-        printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s",\n    "brace-expansion": "%s",\n    "glob": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" "${BRACE_EXPANSION_VERSION}" "${GLOB_VERSION}" > "${PATCH_DIR}/package.json"; \
+        printf '{\n  "name": "runner-patch",\n  "private": true,\n  "version": "1.0.0",\n  "dependencies": {\n    "cross-spawn": "%s",\n    "tar": "%s",\n    "brace-expansion": "%s",\n    "@isaacs/brace-expansion": "%s",\n    "glob": "%s",\n    "minimatch": "%s",\n    "diff": "%s"\n  }\n}\n' "${CROSS_SPAWN_VERSION}" "${TAR_VERSION}" "${BRACE_EXPANSION_VERSION}" "${ISAACS_BRACE_EXPANSION_VERSION}" "${GLOB_VERSION}" "${MINIMATCH_VERSION}" "${DIFF_VERSION}" > "${PATCH_DIR}/package.json"; \
         "${NODE_ROOT}bin/node" "${NPM_DIR}/bin/npm-cli.js" install --prefix="${PATCH_DIR}" --omit=dev --cache /tmp/npm-cache; \
-        rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar" "${NPM_DIR}/node_modules/brace-expansion" "${NPM_DIR}/node_modules/glob"; \
+        rm -rf "${NPM_DIR}/node_modules/cross-spawn" "${NPM_DIR}/node_modules/tar" "${NPM_DIR}/node_modules/brace-expansion" "${NPM_DIR}/node_modules/@isaacs/brace-expansion" "${NPM_DIR}/node_modules/glob" "${NPM_DIR}/node_modules/minimatch" "${NPM_DIR}/node_modules/diff"; \
         cp -a "${PATCH_DIR}/node_modules/." "${NPM_DIR}/node_modules/"; \
         rm -rf "${PATCH_DIR}" "${NPM_DIR}/node_modules/.npm"; \
     fi; \


### PR DESCRIPTION
## Summary
- patch embedded npm dependency sets in all runner Dockerfiles
- add targeted overrides for minimatch, diff, and @isaacs/brace-expansion
- bump tar patch level and Go toolchain in chrome-go image

## Scope
- only targets develop branch via this feature PR
- focused on open code-scanning findings for refs/heads/develop