### PR TITLE
fix(ci): remove broken manual trivy wget install steps

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -452,10 +452,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Install Trivy
-        run: |
-          wget -qO /tmp/trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v0.69.1/trivy_0.69.1_Linux-64bit.tar.gz
-          tar xzf /tmp/trivy.tar.gz -C /usr/local/bin trivy
       - name: Run Trivy vulnerability scanner on filesystem
         uses: aquasecurity/trivy-action@0.34.1
         with:
@@ -465,7 +461,6 @@ jobs:
           output: "trivy-results.sarif"
           timeout: "10m"
           skip-dirs: "test-results,logs,.git"
-          skip-setup-trivy: true
       - name: Upload Trivy scan results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
         if: always()
@@ -1132,10 +1127,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
-      - name: Install Trivy
-        run: |
-          wget -qO /tmp/trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v0.69.1/trivy_0.69.1_Linux-64bit.tar.gz
-          tar xzf /tmp/trivy.tar.gz -C /usr/local/bin trivy
       - name: Run Trivy vulnerability scanner on container
         uses: aquasecurity/trivy-action@0.34.1
         with:
@@ -1144,7 +1135,6 @@ jobs:
           output: "trivy-container-results.sarif"
           timeout: "15m"
           severity: "CRITICAL,HIGH"
-          skip-setup-trivy: true
       - name: Upload container scan results
         uses: github/codeql-action/upload-sarif@v4
         if: always()
@@ -1164,10 +1154,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
-      - name: Install Trivy
-        run: |
-          wget -qO /tmp/trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v0.69.1/trivy_0.69.1_Linux-64bit.tar.gz
-          tar xzf /tmp/trivy.tar.gz -C /usr/local/bin trivy
       - name: Run Trivy vulnerability scanner on Chrome container
         uses: aquasecurity/trivy-action@0.34.1
         with:
@@ -1176,7 +1162,6 @@ jobs:
           output: "trivy-chrome-results.sarif"
           timeout: "15m"
           severity: "CRITICAL,HIGH"
-          skip-setup-trivy: true
       - name: Upload Chrome container scan results
         uses: github/codeql-action/upload-sarif@v4
         if: always()
@@ -1196,10 +1181,6 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
-      - name: Install Trivy
-        run: |
-          wget -qO /tmp/trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v0.69.1/trivy_0.69.1_Linux-64bit.tar.gz
-          tar xzf /tmp/trivy.tar.gz -C /usr/local/bin trivy
       - name: Run Trivy vulnerability scanner on Chrome-Go container
         uses: aquasecurity/trivy-action@0.34.1
         with:
@@ -1208,7 +1189,6 @@ jobs:
           output: "trivy-chrome-go-results.sarif"
           timeout: "15m"
           severity: "CRITICAL,HIGH"
-          skip-setup-trivy: true
       - name: Upload Chrome-Go container scan results
         uses: github/codeql-action/upload-sarif@v4
         if: always()


### PR DESCRIPTION
Re-applies the fix from #1104 which was reverted by the back-sync merge from main (main still carried the broken steps). Removes 4x manual wget Install Trivy steps and skip-setup-trivy from all trivy-action uses.