### PR TITLE
chore: promote develop to main

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -452,6 +452,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+      - name: Install Trivy via apt
+        run: |
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update -qq && sudo apt-get install -y trivy
       - name: Run Trivy vulnerability scanner on filesystem
         uses: aquasecurity/trivy-action@0.34.1
         with:
@@ -461,6 +466,7 @@ jobs:
           output: "trivy-results.sarif"
           timeout: "10m"
           skip-dirs: "test-results,logs,.git"
+          skip-setup-trivy: true
       - name: Upload Trivy scan results to GitHub Security
         uses: github/codeql-action/upload-sarif@v4
         if: always()
@@ -1127,6 +1133,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+      - name: Install Trivy via apt
+        run: |
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update -qq && sudo apt-get install -y trivy
       - name: Run Trivy vulnerability scanner on container
         uses: aquasecurity/trivy-action@0.34.1
         with:
@@ -1135,6 +1146,7 @@ jobs:
           output: "trivy-container-results.sarif"
           timeout: "15m"
           severity: "CRITICAL,HIGH"
+          skip-setup-trivy: true
       - name: Upload container scan results
         uses: github/codeql-action/upload-sarif@v4
         if: always()
@@ -1154,6 +1166,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+      - name: Install Trivy via apt
+        run: |
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update -qq && sudo apt-get install -y trivy
       - name: Run Trivy vulnerability scanner on Chrome container
         uses: aquasecurity/trivy-action@0.34.1
         with:
@@ -1162,6 +1179,7 @@ jobs:
           output: "trivy-chrome-results.sarif"
           timeout: "15m"
           severity: "CRITICAL,HIGH"
+          skip-setup-trivy: true
       - name: Upload Chrome container scan results
         uses: github/codeql-action/upload-sarif@v4
         if: always()
@@ -1181,6 +1199,11 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 1
+      - name: Install Trivy via apt
+        run: |
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update -qq && sudo apt-get install -y trivy
       - name: Run Trivy vulnerability scanner on Chrome-Go container
         uses: aquasecurity/trivy-action@0.34.1
         with:
@@ -1189,6 +1212,7 @@ jobs:
           output: "trivy-chrome-go-results.sarif"
           timeout: "15m"
           severity: "CRITICAL,HIGH"
+          skip-setup-trivy: true
       - name: Upload Chrome-Go container scan results
         uses: github/codeql-action/upload-sarif@v4
         if: always()

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -220,10 +220,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Install Trivy
+      - name: Install Trivy via apt
         run: |
-          wget -qO /tmp/trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v0.69.1/trivy_0.69.1_Linux-64bit.tar.gz
-          tar xzf /tmp/trivy.tar.gz -C /usr/local/bin trivy
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update -qq && sudo apt-get install -y trivy
 
       - name: Run comprehensive security scan
         uses: aquasecurity/trivy-action@0.34.1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,10 +239,11 @@ jobs:
       matrix:
         scan: [standard, chrome, chrome-go]
     steps:
-      - name: Install Trivy
+      - name: Install Trivy via apt
         run: |
-          wget -qO /tmp/trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v0.69.1/trivy_0.69.1_Linux-64bit.tar.gz
-          tar xzf /tmp/trivy.tar.gz -C /usr/local/bin trivy
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update -qq && sudo apt-get install -y trivy
       - name: Run Trivy vulnerability scanner (standard)
         if: matrix.scan == 'standard'
         uses: aquasecurity/trivy-action@0.34.1

--- a/.github/workflows/security-advisories.yml
+++ b/.github/workflows/security-advisories.yml
@@ -59,10 +59,11 @@ jobs:
       - name: Create results directory
         run: mkdir -p trivy-results
 
-      - name: Install Trivy
+      - name: Install Trivy via apt
         run: |
-          wget -qO /tmp/trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v0.69.1/trivy_0.69.1_Linux-64bit.tar.gz
-          tar xzf /tmp/trivy.tar.gz -C /usr/local/bin trivy
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update -qq && sudo apt-get install -y trivy
 
       # Filesystem vulnerability scan
       - name: Run Trivy filesystem scan

--- a/.github/workflows/seed-trivy-sarif.yml
+++ b/.github/workflows/seed-trivy-sarif.yml
@@ -57,10 +57,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
-      - name: Install Trivy
+      - name: Install Trivy via apt
         run: |
-          wget -qO /tmp/trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v0.69.1/trivy_0.69.1_Linux-64bit.tar.gz
-          tar xzf /tmp/trivy.tar.gz -C /usr/local/bin trivy
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update -qq && sudo apt-get install -y trivy
 
       - name: Run Trivy filesystem scan (generate SARIF)
         uses: aquasecurity/trivy-action@0.34.1
@@ -125,10 +126,11 @@ jobs:
       - name: Verify image loaded
         run: docker images | grep github-runner-${{ matrix.variant }}
 
-      - name: Install Trivy
+      - name: Install Trivy via apt
         run: |
-          wget -qO /tmp/trivy.tar.gz https://github.com/aquasecurity/trivy/releases/download/v0.69.1/trivy_0.69.1_Linux-64bit.tar.gz
-          tar xzf /tmp/trivy.tar.gz -C /usr/local/bin trivy
+          wget -qO - https://aquasecurity.github.io/trivy-repo/deb/public.key | gpg --dearmor | sudo tee /usr/share/keyrings/trivy.gpg > /dev/null
+          echo "deb [signed-by=/usr/share/keyrings/trivy.gpg] https://aquasecurity.github.io/trivy-repo/deb generic main" | sudo tee /etc/apt/sources.list.d/trivy.list
+          sudo apt-get update -qq && sudo apt-get install -y trivy
 
       - name: Run Trivy container scan (generate SARIF)
         uses: aquasecurity/trivy-action@0.34.1


### PR DESCRIPTION
Promotes develop to main. Includes fix(ci): remove broken manual trivy wget install steps (#1106) — removes 4x broken manual wget trivy install steps that were causing all security scan jobs to fail.