### PR TITLE
fix(ci): grant contents:write to release build jobs for SBOM upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate-release]
     permissions:
-      contents: read
+      contents: write
       packages: write
     outputs:
       image-digest: ${{ steps.build.outputs.digest }}
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate-release]
     permissions:
-      contents: read
+      contents: write
       packages: write
     outputs:
       image-digest: ${{ steps.build.outputs.digest }}
@@ -174,7 +174,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate-release
     permissions:
-      contents: read
+      contents: write
       packages: write
     outputs:
       image-digest: ${{ steps.build.outputs.digest }}


### PR DESCRIPTION
Fixes the v2.5.0 release pipeline failure (run #29).

**Root cause:** All three build jobs (Build Standard Artifacts, Build Chrome Artifacts, Build Chrome-Go Runner Artifacts) had `contents: read` permission, but `anchore/sbom-action@v0` defaults to `upload-release-assets: true`, which requires `contents: write` to attach SBOM files to the GitHub release.

**Error:** `Resource not accessible by integration` at the Generate SBOM step in all three build jobs.

**Fix:** Change `contents: read` to `contents: write` in the permissions block of all three build jobs. The security-scan job retains `contents: read` since it does not upload release assets.