### PR TITLE
chore: promote develop to main - release pipeline fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate-release]
     permissions:
-      contents: read
+      contents: write
       packages: write
     outputs:
       image-digest: ${{ steps.build.outputs.digest }}
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [validate-release]
     permissions:
-      contents: read
+      contents: write
       packages: write
     outputs:
       image-digest: ${{ steps.build.outputs.digest }}
@@ -174,7 +174,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: validate-release
     permissions:
-      contents: read
+      contents: write
       packages: write
     outputs:
       image-digest: ${{ steps.build.outputs.digest }}


### PR DESCRIPTION
Promotes the SBOM permission fix (PR #1122) to main so the v2.5.0 release pipeline can be re-run successfully. Use regular merge (not squash).