### PR TITLE
fix(ci): add checkout step before local install-trivy action in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,8 @@ jobs:
       matrix:
         scan: [standard, chrome, chrome-go]
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
       - name: Install Trivy
         uses: ./.github/actions/install-trivy
       - name: Run Trivy vulnerability scanner (standard)


### PR DESCRIPTION
Fixes the second v2.5.0 release pipeline failure. The security-scan-release job uses the local composite action `.github/actions/install-trivy` but was missing a `checkout` step. Without checkout, the runner can't find the local action.yml, producing: `Can't find 'action.yml' under '.github/actions/install-trivy'`.