### PR TITLE
chore: promote develop to main - release pipeline security scan fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,6 +239,8 @@ jobs:
       matrix:
         scan: [standard, chrome, chrome-go]
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
       - name: Install Trivy
         uses: ./.github/actions/install-trivy
       - name: Run Trivy vulnerability scanner (standard)


### PR DESCRIPTION
Promotes the missing checkout fix (PR #1124) to main so the v2.5.0 release pipeline security scan job can run successfully. Use regular merge (not squash).