### PR TITLE
docs: fix 5 broken documentation links from maintenance run 229

### DIFF
--- a/docs/PERFORMANCE_OPTIMIZATIONS.md
+++ b/docs/PERFORMANCE_OPTIMIZATIONS.md
@@ -419,7 +419,7 @@ docker buildx prune --keep-storage 10GB  # Keep 10GB
 
 **Status:** ❌ **REJECTED** (November 16, 2025)  
 **Branch:** feature/parallel-npm-installs  
-**Analysis:** [PARALLEL_NPM_RESULTS.md](features/PARALLEL_NPM_RESULTS.md)  
+**Analysis:** Rejected — results not retained  
 **Workflows:** [#19396882450](https://github.com/GrammaTonic/github-runner/actions/runs/19396882450), [#19396967351](https://github.com/GrammaTonic/github-runner/actions/runs/19396967351)
 
 **Original Goal:**

--- a/docs/features/PHASE2_IMPLEMENTATION_SUMMARY.md
+++ b/docs/features/PHASE2_IMPLEMENTATION_SUMMARY.md
@@ -239,8 +239,8 @@ sum(github_runner_jobs_total) by (runner_type, status)
 
 ## 📚 Documentation
 
-- **Testing Guide**: [tests/integration/PHASE2_TESTING_GUIDE.md](./tests/integration/PHASE2_TESTING_GUIDE.md)
-- **Integration Test**: [tests/integration/test-phase2-metrics.sh](./tests/integration/test-phase2-metrics.sh)
+- **Testing Guide**: [tests/integration/PHASE2_TESTING_GUIDE.md](../../tests/integration/PHASE2_TESTING_GUIDE.md)
+- **Integration Test**: [tests/integration/test-phase2-metrics.sh](../../tests/integration/test-phase2-metrics.sh)
 - **Issue #1060**: [Phase 2 Requirements](https://github.com/GrammaTonic/github-runner/issues/1060)
 - **Phase 1 PR**: [#1066](https://github.com/GrammaTonic/github-runner/pull/1066)
 

--- a/docs/features/PROMETHEUS_TIMELINE_VISUAL.md
+++ b/docs/features/PROMETHEUS_TIMELINE_VISUAL.md
@@ -195,6 +195,6 @@ Legend:
 
 **Quick Navigation:**
 - 📋 [Full Roadmap](./PROMETHEUS_ROADMAP.md)
-- 📖 [Implementation Plan](/plan/feature-prometheus-monitoring-1.md)
+- 📖 [Implementation Plan](../../plan/feature-prometheus-monitoring-1.md)
 - 📄 [Feature Specification](./PROMETHEUS_IMPROVEMENTS.md)
 - 🔗 [GitHub Project #5](https://github.com/users/GrammaTonic/projects/5)

--- a/docs/features/prometheus-metrics-phase1.md
+++ b/docs/features/prometheus-metrics-phase1.md
@@ -422,7 +422,7 @@ Extend metrics support to Chrome and Chrome-Go runner variants:
 
 For issues or questions:
 
-1. Check [SUPPORT.md](../community/SUPPORT.md)
+1. Check [CONTRIBUTING.md](../community/CONTRIBUTING.md)
 2. Search existing [GitHub Issues](https://github.com/GrammaTonic/github-runner/issues)
 3. Create a new issue with the `metrics` label
 


### PR DESCRIPTION
## Summary

Fixes all 5 broken documentation links reported by maintenance workflow run #229.

## Changes

| File | Broken Link | Fix |
|---|---|---|
| PHASE2_IMPLEMENTATION_SUMMARY.md | `./tests/integration/PHASE2_TESTING_GUIDE.md` | Fixed relative path to `../../tests/integration/...` |
| PHASE2_IMPLEMENTATION_SUMMARY.md | `./tests/integration/test-phase2-metrics.sh` | Fixed relative path to `../../tests/integration/...` |
| PROMETHEUS_TIMELINE_VISUAL.md | `/plan/feature-prometheus-monitoring-1.md` | Replaced absolute path with relative `../../plan/...` |
| prometheus-metrics-phase1.md | `../community/SUPPORT.md` | File doesn't exist; replaced with `CONTRIBUTING.md` |
| PERFORMANCE_OPTIMIZATIONS.md | `features/PARALLEL_NPM_RESULTS.md` | File never created (rejected feature); removed dead link |

## Type of Change
- Documentation update
