### PR TITLE
fix: add link-check ignore patterns for localhost and private URLs

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -23,6 +23,12 @@
       "pattern": "^https://github\\.com/.*/wiki/"
     },
     {
+      "pattern": "^https://github\\.com/users/.*/projects/"
+    },
+    {
+      "pattern": "^https?://localhost[:/]"
+    },
+    {
       "pattern": "^#"
     }
   ]


### PR DESCRIPTION
Adds ignore patterns to `.markdown-link-check.json` for:
- `http(s)://localhost` URLs (documentation examples, unreachable in CI)
- `https://github.com/users/*/projects/` URLs (private project boards, return 404 in CI)

Fixes the docs-validation failure on PR #1128 (develop to main promotion).