### PR TITLE
perf: replace super-linter with markdownlint-cli2-action

### DIFF
--- a/.github/workflows/auto-sync-docs.yml
+++ b/.github/workflows/auto-sync-docs.yml
@@ -186,15 +186,11 @@ jobs:
 
           resp=$(curl -sS -H "Authorization: Bearer $GITHUB_TOKEN" -H "Accept: application/vnd.github+json" -X POST "$API_URL" --data "$PAYLOAD" || true)
           echo "$resp" | jq -r '.html_url // .message'
-      - name: Run GitHub Super Linter for Docs
+      - name: Lint Markdown
         # yamllint disable-line rule:line-length
-        uses: super-linter/super-linter@12150456a73e248bdc94d0794898f94e23127c88  # v7
-        env:
-          DEFAULT_BRANCH: develop
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: false
-          VALIDATE_MARKDOWN: true
-          VALIDATE_JSCPD: false
-          VALIDATE_CHECKOV: false
-          FILTER_REGEX_INCLUDE: (docs|wiki-content)/.*
-          FILTER_REGEX_EXCLUDE: docs/archive/.*
+        uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101  # v22.0.0
+        with:
+          globs: |
+            docs/**/*.md
+            wiki-content/**/*.md
+            !docs/archive/**

--- a/.github/workflows/docs-validation.yml
+++ b/.github/workflows/docs-validation.yml
@@ -5,10 +5,10 @@ on:
     paths:
       - 'docs/**'
       - 'wiki-content/**'
+  workflow_dispatch:
 
 permissions:
   contents: read
-  statuses: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -23,6 +23,7 @@ jobs:
           fetch-depth: 1
 
       - name: Fetch PR base for patch diff
+        if: github.event_name == 'pull_request'
         run: |
           git fetch origin ${{ github.event.pull_request.base.sha }} --depth=1
 
@@ -78,24 +79,22 @@ jobs:
           fi
 
       - name: Generate Documentation Patch
+        if: github.event_name == 'pull_request'
         run: |
           git diff ${{ github.event.pull_request.base.sha }} -- docs/ wiki-content/ > docs-full-patch.diff || echo "No doc changes detected."
 
       - name: Upload Patch Artifact
+        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@v6
         with:
           name: docs-full-patch
           path: docs-full-patch.diff
 
-      - name: Run GitHub Super Linter for Docs
+      - name: Lint Markdown
         # yamllint disable-line rule:line-length
-        uses: super-linter/super-linter@12150456a73e248bdc94d0794898f94e23127c88  # v7
-        env:
-          DEFAULT_BRANCH: develop
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: false
-          VALIDATE_MARKDOWN: true
-          VALIDATE_JSCPD: false
-          VALIDATE_CHECKOV: false
-          FILTER_REGEX_INCLUDE: (docs|wiki-content)/.*
-          FILTER_REGEX_EXCLUDE: docs/archive/.*
+        uses: DavidAnson/markdownlint-cli2-action@07035fd053f7be764496c0f8d8f9f41f98305101  # v22.0.0
+        with:
+          globs: |
+            docs/**/*.md
+            wiki-content/**/*.md
+            !docs/archive/**

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,23 @@
+// Configuration for markdownlint-cli2 — replaces super-linter for Markdown validation.
+// See: https://github.com/DavidAnson/markdownlint-cli2#configuration
+{
+  "config": {
+    // Allow long lines — many docs contain URLs, tables, and code blocks
+    "MD013": false,
+    // Allow duplicate headings in sibling sections (e.g. multiple "Usage" under different parents)
+    "MD024": { "siblings_only": true },
+    // Allow inline HTML (badges, images, diagrams, details/summary blocks)
+    "MD033": false,
+    // Allow bare URLs — common in reference docs and config examples
+    "MD034": false,
+    // Allow multiple blank lines (common after HTML blocks)
+    "MD012": false,
+    // Allow first line to be non-heading (frontmatter, comments, etc.)
+    "MD041": false
+  },
+  "globs": [
+    "docs/**/*.md",
+    "wiki-content/**/*.md",
+    "!docs/archive/**"
+  ]
+}


### PR DESCRIPTION
## Summary

Replace the heavyweight super-linter Docker image (~2.5 GB pull, 90s+ step) with the lightweight DavidAnson/markdownlint-cli2-action v22.0.0 (~3-5s) for Markdown linting in both documentation workflows.

## Type of Change

- [x] Performance improvement

## Changes Made

- .markdownlint-cli2.jsonc: New config with MD013/MD033/MD034/MD012/MD041 disabled, MD024 siblings-only, globs for docs + wiki
- docs-validation.yml: Replaced super-linter step; removed statuses:write permission
- auto-sync-docs.yml: Replaced super-linter step with markdownlint-cli2-action

## Performance Impact

- Image pull: ~2.5 GB Docker image -> ~15 MB Node.js action
- Step duration: 90-120s -> 3-5s
- Network: Docker pull every run -> npm cache-friendly

## Testing

- yamllint passes on both workflow files
- YAML structure validated
- CI pipeline run will validate end-to-end

/cc @copilot
