### PR TITLE
fix: add discussions URL to link-check ignore patterns

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -23,6 +23,9 @@
       "pattern": "^https://github\\.com/.*/wiki/"
     },
     {
+      "pattern": "^https://github\\.com/.*/discussions"
+    },
+    {
       "pattern": "^https://github\\.com/users/"
     },
     {


### PR DESCRIPTION
Discussions returns HTTP 502 when the feature is not enabled on the repository, causing the validate-docs workflow to fail. Adds an ignore pattern for `/discussions` URLs alongside the existing `/wiki/` and `/settings/` patterns.