### PR TITLE
feat(prometheus): Phase 2 - fix Chrome/Chrome-Go metrics gaps

### DIFF
--- a/config/chrome-go-runner.env.example
+++ b/config/chrome-go-runner.env.example
@@ -67,6 +67,19 @@ GO_TEST_TIMEOUT=10m
 GOMODCACHE=/home/runner/go/pkg/mod
 
 # ==========================================
+# OPTIONAL: Prometheus Metrics Configuration
+# ==========================================
+
+# Runner type label exposed in Prometheus metrics
+# RUNNER_TYPE=chrome-go
+
+# Port for the Prometheus metrics endpoint (container-internal; host port mapped in docker-compose)
+# METRICS_PORT=9091
+
+# Interval in seconds between metrics collection updates
+# METRICS_UPDATE_INTERVAL=30
+
+# ==========================================
 # PERFORMANCE AND RESOURCE CONFIGURATION
 # ==========================================
 

--- a/config/chrome-runner.env.example
+++ b/config/chrome-runner.env.example
@@ -55,6 +55,19 @@ SCREEN_WIDTH=1920
 SCREEN_HEIGHT=1080
 SCREEN_DEPTH=24
 
+# ==========================================
+# OPTIONAL: Prometheus Metrics Configuration
+# ==========================================
+
+# Runner type label exposed in Prometheus metrics
+# RUNNER_TYPE=chrome
+
+# Port for the Prometheus metrics endpoint (container-internal; host port mapped in docker-compose)
+# METRICS_PORT=9091
+
+# Interval in seconds between metrics collection updates
+# METRICS_UPDATE_INTERVAL=30
+
 # Memory limits
 CHROME_MAX_MEMORY=2048
 NODE_MAX_MEMORY=4096

--- a/docker/Dockerfile.chrome
+++ b/docker/Dockerfile.chrome
@@ -88,6 +88,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libicu-dev \
     # Chrome & UI testing dependencies (existing)
     libnss3 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxtst6 libatk1.0-0 libatk-bridge2.0-0 libdrm2 libgbm1 libasound2-dev libatspi2.0-0 libgtk-3-0 libpangocairo-1.0-0 libcairo2 libgdk-pixbuf-2.0-0 fonts-liberation fonts-noto-color-emoji fonts-noto-cjk xvfb procps \
+    # Metrics endpoint dependency (required by metrics-server.sh)
+    netcat-openbsd \
     # Python
     python3 python3-pip python3-venv \
     # Playwright/Chromium/Chrome required libraries (Ubuntu 24.04 compatible)

--- a/docker/Dockerfile.chrome-go
+++ b/docker/Dockerfile.chrome-go
@@ -89,6 +89,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     libicu-dev \
     # Chrome & UI testing dependencies (existing)
     libnss3 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxtst6 libatk1.0-0 libatk-bridge2.0-0 libdrm2 libgbm1 libasound2-dev libatspi2.0-0 libgtk-3-0 libpangocairo-1.0-0 libcairo2 libgdk-pixbuf-2.0-0 fonts-liberation fonts-noto-color-emoji fonts-noto-cjk xvfb procps \
+    # Metrics endpoint dependency (required by metrics-server.sh)
+    netcat-openbsd \
     # Python
     python3 python3-pip python3-venv \
     # Playwright/Chromium/Chrome required libraries (Ubuntu 24.04 compatible)

--- a/docker/entrypoint-chrome.sh
+++ b/docker/entrypoint-chrome.sh
@@ -28,21 +28,11 @@ validate_hostname() {
 	return 0
 }
 
-# Check for required environment variables
-: "${GITHUB_TOKEN:?Error: GITHUB_TOKEN environment variable not set.}"
-: "${GITHUB_REPOSITORY:?Error: GITHUB_REPOSITORY environment variable not set.}"
-
-# Validate inputs before using them
-validate_repository "$GITHUB_REPOSITORY" || exit 1
-
-# Optional variables with default values
+# Optional variables with default values (set before metrics for RUNNER_NAME usage)
 RUNNER_NAME="${RUNNER_NAME:-chrome-runner-$(hostname)}"
 RUNNER_LABELS="${RUNNER_LABELS:-chrome,ui-tests,playwright,cypress}"
 RUNNER_WORK_DIR="${RUNNER_WORK_DIR:-/home/runner/workspace}"
 GITHUB_HOST="${GITHUB_HOST:-github.com}" # For GitHub Enterprise
-
-# Validate GitHub host
-validate_hostname "$GITHUB_HOST" || exit 1
 
 # --- METRICS SETUP (Phase 2: Prometheus Monitoring) ---
 # Start metrics services BEFORE token validation to enable standalone testing
@@ -105,6 +95,17 @@ if [ -f "/usr/local/bin/metrics-server.sh" ]; then
 else
 	echo "Warning: metrics-server.sh not found, metrics endpoint disabled"
 fi
+
+# --- GITHUB RUNNER SETUP ---
+# Check for required environment variables (after metrics so endpoint works standalone)
+: "${GITHUB_TOKEN:?Error: GITHUB_TOKEN environment variable not set.}"
+: "${GITHUB_REPOSITORY:?Error: GITHUB_REPOSITORY environment variable not set.}"
+
+# Validate inputs before using them
+validate_repository "$GITHUB_REPOSITORY" || exit 1
+
+# Validate GitHub host
+validate_hostname "$GITHUB_HOST" || exit 1
 
 # Change to the runner's directory
 cd /actions-runner

--- a/monitoring/prometheus.yml
+++ b/monitoring/prometheus.yml
@@ -48,10 +48,26 @@ scrape_configs:
     scrape_interval: 30s
     metrics_path: /metrics
 
-  # GitHub Runner application metrics
-  - job_name: "github-runner"
+  # GitHub Runner application metrics - Standard runner
+  - job_name: "github-runner-standard"
     static_configs:
-      - targets: ["runner:8080"]
+      - targets: ["github-runner-main:9091"]
+    scrape_interval: 15s
+    metrics_path: /metrics
+    scrape_timeout: 10s
+
+  # GitHub Runner application metrics - Chrome runner
+  - job_name: "github-runner-chrome"
+    static_configs:
+      - targets: ["github-runner-chrome:9091"]
+    scrape_interval: 15s
+    metrics_path: /metrics
+    scrape_timeout: 10s
+
+  # GitHub Runner application metrics - Chrome-Go runner
+  - job_name: "github-runner-chrome-go"
+    static_configs:
+      - targets: ["github-runner-chrome-go:9091"]
     scrape_interval: 15s
     metrics_path: /metrics
     scrape_timeout: 10s


### PR DESCRIPTION
## Summary

Fixes the remaining gaps in the Phase 2 Prometheus metrics implementation for Chrome and Chrome-Go runners (Issue #1060, TASK-013 through TASK-019).

All code-level tasks were already implemented on develop, but four blockers/gaps prevented successful build and runtime validation (TASK-020 through TASK-026). This PR addresses all four.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Configuration change

## Related Issues

- Closes #1060
- Follows up on #1059 (Phase 1 - Standard Runner, complete)

## Changes Made

### 1. Add netcat-openbsd to Chrome Dockerfiles (BLOCKER fix)

metrics-server.sh requires nc (netcat). The standard Dockerfile already installs netcat-openbsd, but both Chrome variants were missing it. Without this, the metrics HTTP server silently fails at runtime.

- docker/Dockerfile.chrome - added netcat-openbsd to apt-get install
- docker/Dockerfile.chrome-go - added netcat-openbsd to apt-get install

### 2. Reorder Chrome entrypoint token validation

entrypoint-chrome.sh checked GITHUB_TOKEN before starting metrics, despite a comment saying Start metrics services BEFORE token validation. The standard entrypoint.sh correctly starts metrics first. This reordering matches that pattern and enables standalone metrics testing.

### 3. Update Prometheus scrape targets

monitoring/prometheus.yml still had the stale placeholder runner:8080. Updated to per-variant scrape jobs matching the actual Docker Compose service names and ports.

### 4. Document metrics env vars in config examples

Added RUNNER_TYPE, METRICS_PORT, and METRICS_UPDATE_INTERVAL entries to config/chrome-runner.env.example and config/chrome-go-runner.env.example.

## Checklist

- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] Changes are backward-compatible
- [x] Port mappings follow the established convention (9091 internal, unique host ports)
