### PR TITLE
chore: promote develop to main - SBOM & vulnerability validation fix

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -570,7 +570,7 @@ jobs:
           platforms: ${{ steps.platforms.outputs.platforms }}
           file: ./docker/Dockerfile
           push: true
-          load: false
+          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: ${{ steps.force-rebuild-normal.outputs.cache_from }}
@@ -671,7 +671,7 @@ jobs:
           platforms: linux/amd64
           file: ./docker/Dockerfile.chrome
           push: true
-          load: false
+          load: true
           tags: ${{ steps.meta-chrome.outputs.tags }}
           labels: ${{ steps.meta-chrome.outputs.labels }}
           cache-from: ${{ steps.force-rebuild-chrome.outputs.cache_from }}
@@ -772,7 +772,7 @@ jobs:
           platforms: linux/amd64
           file: ./docker/Dockerfile.chrome-go
           push: true
-          load: false
+          load: true
           tags: ${{ steps.meta-chrome-go.outputs.tags }}
           labels: ${{ steps.meta-chrome-go.outputs.labels }}
           cache-from: ${{ steps.force-rebuild-chrome-go.outputs.cache_from }}


### PR DESCRIPTION
Promotes the latest develop branch changes to main, including the fix for SBOM & vulnerability validation by loading images for Trivy scan.\n\n- Ensures Trivy scans work reliably\n- Resolves previous workflow failure\n- No breaking changes\n\n/cc @copilot