### PR TITLE
🔒 Remove unnecessary sudo installation from Chrome Dockerfiles

### DIFF
--- a/docker/Dockerfile.chrome
+++ b/docker/Dockerfile.chrome
@@ -79,7 +79,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get update && apt-get upgrade -y \
     && apt-get install -y --no-install-recommends \
         curl ca-certificates gnupg wget unzip xz-utils \
-        sudo git jq \
+        git jq \
         # All other packages are system libraries, version-pinned by Ubuntu Resolute base image
         libnss3 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxtst6 libatk1.0-0 libatk-bridge2.0-0 libdrm2 libgbm1 libasound2-dev libatspi2.0-0 libgtk-3-0 libpangocairo-1.0-0 libcairo2 libgdk-pixbuf-2.0-0 fonts-liberation fonts-noto-color-emoji fonts-noto-cjk xvfb procps libicu-dev \
         netcat-openbsd \

--- a/docker/Dockerfile.chrome-go
+++ b/docker/Dockerfile.chrome-go
@@ -87,7 +87,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     apt-get update \
     && apt-get install -y --no-install-recommends \
         curl ca-certificates gnupg wget unzip xz-utils \
-        sudo git jq \
+        git jq \
         # All other packages are system libraries, version-pinned by Ubuntu Resolute base image
         libnss3 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxtst6 libatk1.0-0 libatk-bridge2.0-0 libdrm2 libgbm1 libasound2-dev libatspi2.0-0 libgtk-3-0 libpangocairo-1.0-0 libcairo2 libgdk-pixbuf-2.0-0 fonts-liberation fonts-noto-color-emoji fonts-noto-cjk xvfb procps \
         netcat-openbsd \


### PR DESCRIPTION
🎯 **What:** The `sudo` package was removed from `docker/Dockerfile.chrome` and `docker/Dockerfile.chrome-go`.
⚠️ **Risk:** Including `sudo` in a container that runs processes as a non-root user (`runner`) provides a potential vector for privilege escalation if an attacker gains access to the container or if a vulnerability allows executing arbitrary commands.
🛡️ **Solution:** Removed `sudo` from the package installation lists in both relevant Dockerfiles. Build steps don't require `sudo` since Docker builds run as root by default. This change reduces the attack surface without impacting functionality.

---
*PR created automatically by Jules for task [14543389677209104855](https://jules.google.com/task/14543389677209104855) started by @GrammaTonic*