### PR TITLE
fix(ci): remove load for multi-platform builds

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -570,7 +570,6 @@ jobs:
           platforms: ${{ steps.platforms.outputs.platforms }}
           file: ./docker/Dockerfile
           push: true
-          load: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: ${{ steps.force-rebuild-normal.outputs.cache_from }}


### PR DESCRIPTION
Remove `load: true` from the normal runner build step when building multiple platforms to avoid the 'docker exporter does not currently support exporting manifest lists' error. This PR updates the CI workflow to push multi-platform images to the registry instead of loading them into the local daemon.