### PR TITLE
🔒 Security Fix: Document omission of sudo from dockerfile

### DIFF
--- a/docker/Dockerfile.chrome-go
+++ b/docker/Dockerfile.chrome-go
@@ -88,6 +88,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get install -y --no-install-recommends \
         curl ca-certificates gnupg wget unzip xz-utils \
         git jq \
+        # Security: sudo deliberately omitted to prevent privilege escalation
         # All other packages are system libraries, version-pinned by Ubuntu Resolute base image
         libnss3 libx11-6 libx11-xcb1 libxcb1 libxcomposite1 libxcursor1 libxdamage1 libxext6 libxfixes3 libxi6 libxtst6 libatk1.0-0 libatk-bridge2.0-0 libdrm2 libgbm1 libasound2-dev libatspi2.0-0 libgtk-3-0 libpangocairo-1.0-0 libcairo2 libgdk-pixbuf-2.0-0 fonts-liberation fonts-noto-color-emoji fonts-noto-cjk xvfb procps \
         netcat-openbsd \


### PR DESCRIPTION
🔒 **Security Fix: Prevent unnecessary `sudo` installation in Dockerfile**

This PR explicitly documents the omission of `sudo` within `docker/Dockerfile.chrome-go`. 

🎯 **What:** The vulnerability concerns the possibility of `sudo` being installed in the container image. The package was already absent in the code tree so this explicitly marks it omitted.
⚠️ **Risk:** If a maintainer inadvertently adds `sudo` for convenience during build steps, it significantly increases the container attack surface by allowing privilege escalation if an attacker manages to execute code inside the container (e.g. escaping the non-root user isolation).
🛡️ **Solution:** Placed an explicit comment where standard tools like `git` and `jq` are installed to indicate `sudo` is deliberately excluded for security reasons, thus preventing future regressions.

---
*PR created automatically by Jules for task [110530562077174928](https://jules.google.com/task/110530562077174928) started by @GrammaTonic*