### PR TITLE
fix: resolve CVE-2026-27142 by updating Go to 1.26.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Note: Documentation workflows and repo prompts were recently improved — see
 | **GitHub Actions Runner** | v2.331.0         | v2.331.0         | v2.331.0         | ✅ Latest         |
 | **Base OS**               | Ubuntu 25.10 Resolute | Ubuntu 25.10 Resolute | Ubuntu 25.10 Resolute | ✅ Pre-release |
 | **Node.js**               | -                | 24.14.0          | 24.14.0          | ✅ Latest         |
-| **Go**                    | -                | -                | 1.26.0           | ✅ Latest         |
+| **Go**                    | -                | -                | 1.26.1           | ✅ Latest         |
 | **Python**                | 3.10+            | 3.10+            | 3.10+            | ✅ Latest         |
 | **Playwright**            | -                | v1.58.2          | v1.58.2          | ✅ Latest         |
 | **Cypress**               | -                | v15.11.0         | v15.11.0         | ✅ Latest         |
@@ -70,7 +70,7 @@ Note: Documentation workflows and repo prompts were recently improved — see
 - ✅ **Dependabot Automation**: Zero-touch dependency updates with auto-merge and hourly auto-rebase workflows
 - ✅ **Performance Optimizations**: BuildKit cache mounts reduce build times by 50-70% (19s standard, 24s Chrome, 4m34s Chrome-Go)
 - ✅ **Multi-Stage Builds**: Standard runner image reduced by 370MB (17% smaller) with improved security
-- ✅ **Chrome-Go Runner**: New variant combining Go 1.26.0 toolchain with browser testing capabilities
+- ✅ **Chrome-Go Runner**: New variant combining Go 1.26.1 toolchain with browser testing capabilities
 - ✅ **Cross-Branch Caching**: Feature branches leverage develop/main cache, eliminating redundant rebuilds
 - ✅ **Image Size Optimizations**: Standard ~1.8GB, Chrome ~4.1GB, Chrome-Go ~4.5GB (all optimized)
 - ✅ **CI/CD Enhancements**: Conditional Dependabot provisioning, artifact status files, clean logs

--- a/docker/Dockerfile.chrome-go
+++ b/docker/Dockerfile.chrome-go
@@ -167,7 +167,7 @@ RUN --mount=type=cache,target=/tmp/npm-cache,uid=0,gid=0 \
 # Use BuildKit cache for Go download
 # Go supports both amd64 and arm64 architectures
 RUN --mount=type=cache,target=/tmp/downloads \
-    GO_VERSION="1.26.0" \
+    GO_VERSION="1.26.1" \
     && case "${TARGETARCH}" in \
         "amd64")  GO_ARCH="amd64"  ;; \
         "arm64")  GO_ARCH="arm64"  ;; \

--- a/docs/PERFORMANCE_OPTIMIZATIONS.md
+++ b/docs/PERFORMANCE_OPTIMIZATIONS.md
@@ -270,7 +270,7 @@ COPY --from=builder /actions-runner /actions-runner
 - Node.js: `24.14.0`
 - npm: `11.11.0`
 - Playwright: `1.58.2`
-- Go: `1.26.0`
+- Go: `1.26.1`
 - cross-spawn: `7.0.6`
 - tar: `7.5.9`
 - brace-expansion: `5.0.4`

--- a/docs/PERFORMANCE_RESULTS.md
+++ b/docs/PERFORMANCE_RESULTS.md
@@ -277,7 +277,7 @@ All external dependencies pinned to specific versions:
 - Chrome: `142.0.7444.162`
 - Node.js: `24.14.0`
 - npm: `11.11.0`
-- Go: `1.26.0`
+- Go: `1.26.1`
 
 **Result:** Consistent cache keys, better cache hit rates
 

--- a/docs/releases/CHANGELOG.md
+++ b/docs/releases/CHANGELOG.md
@@ -31,7 +31,7 @@
 
 - Update Node.js to **24.14.0** (LTS Krypton) in Chrome and Chrome-Go runners.
 - Update npm to **11.11.0** in Chrome and Chrome-Go runners.
-- Update Go to **1.26.0** in Chrome-Go runner.
+- Update Go to **1.26.1** in Chrome-Go runner.
 - Update Playwright to **1.58.2** and `@playwright/test` to **1.58.2** in Chrome and Chrome-Go runners.
 - Update Cypress to **15.11.0** in Chrome and Chrome-Go runners.
 - Update security package overrides: `tar@7.5.9`, `brace-expansion@5.0.4`, `@isaacs/brace-expansion@5.0.1`, `glob@13.0.6`, `minimatch@10.2.4`, `diff@8.0.3`.

--- a/wiki-content/Home.md
+++ b/wiki-content/Home.md
@@ -13,7 +13,7 @@ Welcome to the comprehensive documentation for the GitHub Actions Self-Hosted Ru
 - **Image Versions**: Standard Runner v2.4.0, Chrome Runner v2.4.0, Chrome-Go Runner v2.4.0
 - **Base Image**: Switched to `ubuntu:resolute` (25.10) across all Dockerfiles for latest browser dependencies
 - **Browser Stack**: Chrome for Testing **146.0.7680.31**, Playwright **1.58.2**, Cypress **15.11.0**, Node.js **24.14.0** (LTS Krypton), npm **11.11.0**
-- **Go Toolchain**: Go **1.26.0** in Chrome-Go runner
+- **Go Toolchain**: Go **1.26.1** in Chrome-Go runner
 - **GitHub Actions Runner**: Bumped to **v2.331.0**
 - **Security Overrides**: `tar@7.5.9`, `brace-expansion@5.0.4`, `@isaacs/brace-expansion@5.0.1`, `glob@13.0.6`, `minimatch@10.2.4`, `diff@8.0.3`
 - **CI/CD Fix**: Trivy scanner now installs via apt repository (fixes broken wget download); `trivy-action` pinned to `0.34.1`
@@ -46,7 +46,7 @@ Welcome to the comprehensive documentation for the GitHub Actions Self-Hosted Ru
 | **Chrome for Testing**    | -               | 146.0.7680.31      | 146.0.7680.31      | ✅ Latest               |
 | **Playwright**            | -               | 1.58.2             | 1.58.2             | ✅ Latest               |
 | **Cypress**               | -               | 15.11.0            | 15.11.0            | ✅ Latest               |
-| **Go**                    | -               | -                  | 1.26.0             | ✅ Chrome-Go Only       |
+| **Go**                    | -               | -                  | 1.26.1             | ✅ Chrome-Go Only       |
 
 > 📋 **Full Version Details**: [Version Overview](../docs/VERSION_OVERVIEW.md)
 


### PR DESCRIPTION
Fixes a security vulnerability (CVE-2026-27142) reported by GitHub Code Scanning in the Go standard library (`html/template`). The Go toolchain version in the Chrome-Go runner has been updated from `1.26.0` to `1.26.1`, which contains the patch for this vulnerability. All associated documentation has also been updated to reflect the new version.

---
*PR created automatically by Jules for task [16446901808359015804](https://jules.google.com/task/16446901808359015804) started by @GrammaTonic*